### PR TITLE
auto-destroy wearables if placed back on parent

### DIFF
--- a/DomainContent/AvatarStore/attachmentItemScript.js
+++ b/DomainContent/AvatarStore/attachmentItemScript.js
@@ -25,6 +25,7 @@
     var EMPTY_PARENT_ID = "{00000000-0000-0000-0000-000000000000}";
     var ATTACH_SCALE = 3;
     var MESSAGE_CHANNEL_BASE = "AvatarStoreObject";
+    var NOT_ATTACHED_DESTROY_RADIUS = 0.1;
   
     var messageChannel;
     var highlightConfig = Render.getConfig("UpdateScene.HighlightStageSetup");
@@ -37,6 +38,7 @@
     var prevID = 0;
     var listType = "entity";
     var attachDistance;
+    var initialParentPosition;
 
 
     var attachFunction = function() {
@@ -91,6 +93,7 @@
             Entities.editEntity(entityID, {marketplaceID: _marketplaceID});
             MyAvatar.scaleChanged.connect(attachFunction);
             attachDistance = MyAvatar.getEyeHeight() / ATTACH_SCALE;
+            initialParentPosition = Entities.getEntityProperties(properties.parentID, ['position']).position;
         },
         unload: function() {
             MyAvatar.scaleChanged.disconnect(attachFunction);
@@ -232,7 +235,17 @@
                             localOnly: true
                         });
                     }
+                    isAttached = false;
                     Controller.triggerHapticPulse(TRIGGER_INTENSITY, TRIGGER_TIME, hand);
+                }
+            }
+            
+            if (!isAttached) { 
+                // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
+                // and it is not attached then destroy it (i.e. user is putting it back)
+                if (Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
+                    Entities.deleteEntity(_entityID);
+                    return;
                 }
             }
         }

--- a/DomainContent/AvatarStore/attachmentItemScript.js
+++ b/DomainContent/AvatarStore/attachmentItemScript.js
@@ -241,7 +241,7 @@
             }
             
             // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
-            // and it is not attached then destroy it (i.e. user is putting it back)
+            // and it is not attached then destroy it (if the user is putting it back)
             if (!isAttached && Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
                 Entities.deleteEntity(_entityID);
             }

--- a/DomainContent/AvatarStore/attachmentItemScript.js
+++ b/DomainContent/AvatarStore/attachmentItemScript.js
@@ -24,10 +24,13 @@
     var TRIGGER_TIME = 0.2;
     var EMPTY_PARENT_ID = "{00000000-0000-0000-0000-000000000000}";
     var ATTACH_SCALE = 3;
-    var MESSAGE_CHANNEL_BASE = "AvatarStoreObject";
+    var REMOVED_FROM_PARENT_CHANNEL_BASE = "AvatarStoreRemovedFromParent";
+    var RELEASE_GRAB_CHANNEL_BASE = "AvatarStoreReleaseGrab";
     var NOT_ATTACHED_DESTROY_RADIUS = 0.1;
   
-    var messageChannel;
+    var removedFromParentChannel;
+    var releaseGrabChannel;
+    var releaseGrabHandler;
     var highlightConfig = Render.getConfig("UpdateScene.HighlightStageSetup");
     var _entityID;
     var _attachmentData;
@@ -62,6 +65,17 @@
     function AttachableItem() {
 
     }
+    
+    function CheckReleaseGrabOnParent() {
+        // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
+        // and it is not attached then destroy it (if the user is putting it back)
+        var properties = Entities.getEntityProperties(_entityID, ['userData', 'position']);
+        var isAttached = JSON.parse(properties.userData).Attachment.attached;
+        if (!isAttached && initialParentPositionSet && 
+            Vec3.distance(initialParentPosition, properties.position) < NOT_ATTACHED_DESTROY_RADIUS) {
+            Entities.deleteEntity(_entityID);
+        }
+    }
 
     AttachableItem.prototype = {
         preload : function(entityID) {
@@ -87,9 +101,18 @@
             isAttached = _attachmentData.attached;
 
             if (Entities.getNestableType(properties.parentID) !== "avatar" && !isAttached) {
-                messageChannel = MESSAGE_CHANNEL_BASE + properties.parentID;
-                Messages.subscribe(messageChannel);
+                removedFromParentChannel = REMOVED_FROM_PARENT_CHANNEL_BASE + properties.parentID;
+                Messages.subscribe(removedFromParentChannel);
             }
+            
+            releaseGrabChannel = RELEASE_GRAB_CHANNEL_BASE + entityID;
+            Messages.subscribe(releaseGrabChannel);
+            releaseGrabHandler = function(channel, data, sender) {
+                if (channel === releaseGrabChannel) {
+                    CheckReleaseGrabOnParent();
+                }    
+            };
+            Messages.messageReceived.connect(releaseGrabHandler);
 
             Entities.editEntity(entityID, {marketplaceID: _marketplaceID});
             MyAvatar.scaleChanged.connect(attachFunction);
@@ -103,6 +126,8 @@
         },
         unload: function() {
             MyAvatar.scaleChanged.disconnect(attachFunction);
+            Messages.unsubscribe(releaseGrabChannel);
+            Messages.unsubscribe(removedFromParentChannel);
         },
         /**
          * Local remote function to be called from desktopAttachment.js whenever a click event is registered.
@@ -189,8 +214,8 @@
                 }
             }
             if (Entities.getNestableType(properties.parentID) === "entity") {
-                Messages.sendMessage(messageChannel, "Removed Item :" + entityID);
-                Messages.unsubscribe(messageChannel);
+                Messages.sendMessage(removedFromParentChannel, "Removed Item :" + entityID);
+                Messages.unsubscribe(removedFromParentChannel);
                 Entities.editEntity(entityID, {parentID: EMPTY_PARENT_ID});
             }
             var userData = properties.userData;
@@ -246,12 +271,8 @@
                 }
             }
             
-            // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
-            // and it is not attached then destroy it (if the user is putting it back)
-            if (!isAttached && initialParentPositionSet && 
-                Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
-                Entities.deleteEntity(_entityID);
-            }
+            Messages.sendMessage(releaseGrabChannel, "Released Grab: " + entityID);
+            CheckReleaseGrabOnParent();
         }
     };
     return new AttachableItem(); 

--- a/DomainContent/AvatarStore/attachmentItemScript.js
+++ b/DomainContent/AvatarStore/attachmentItemScript.js
@@ -39,6 +39,7 @@
     var listType = "entity";
     var attachDistance;
     var initialParentPosition;
+    var initialParentPositionSet = false;
 
 
     var attachFunction = function() {
@@ -93,7 +94,12 @@
             Entities.editEntity(entityID, {marketplaceID: _marketplaceID});
             MyAvatar.scaleChanged.connect(attachFunction);
             attachDistance = MyAvatar.getEyeHeight() / ATTACH_SCALE;
-            initialParentPosition = Entities.getEntityProperties(properties.parentID, ['position']).position;
+            
+            // We only want to store the initial parent position for the original parent wearable entity
+            if (properties.parentID != EMPTY_PARENT_ID && Entities.getNestableType(properties.parentID) !== "avatar") {
+                initialParentPosition = Entities.getEntityProperties(properties.parentID, ['position']).position;
+                initialParentPositionSet = true;
+            }
         },
         unload: function() {
             MyAvatar.scaleChanged.disconnect(attachFunction);
@@ -242,7 +248,7 @@
             
             // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
             // and it is not attached then destroy it (if the user is putting it back)
-            if (!isAttached && Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
+            if (!isAttached && initialParentPositionSet && Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
                 Entities.deleteEntity(_entityID);
             }
         }

--- a/DomainContent/AvatarStore/attachmentItemScript.js
+++ b/DomainContent/AvatarStore/attachmentItemScript.js
@@ -248,7 +248,8 @@
             
             // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
             // and it is not attached then destroy it (if the user is putting it back)
-            if (!isAttached && initialParentPositionSet && Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
+            if (!isAttached && initialParentPositionSet && 
+                Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
                 Entities.deleteEntity(_entityID);
             }
         }

--- a/DomainContent/AvatarStore/attachmentItemScript.js
+++ b/DomainContent/AvatarStore/attachmentItemScript.js
@@ -240,13 +240,10 @@
                 }
             }
             
-            if (!isAttached) { 
-                // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
-                // and it is not attached then destroy it (i.e. user is putting it back)
-                if (Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
-                    Entities.deleteEntity(_entityID);
-                    return;
-                }
+            // If placed back within NOT_ATTACHED_DESTROY_RADIUS of the original parent entity 
+            // and it is not attached then destroy it (i.e. user is putting it back)
+            if (!isAttached && Vec3.distance(initialParentPosition, position) < NOT_ATTACHED_DESTROY_RADIUS) {
+                Entities.deleteEntity(_entityID);
             }
         }
     };

--- a/DomainContent/AvatarStore/wearableServer.js
+++ b/DomainContent/AvatarStore/wearableServer.js
@@ -8,13 +8,13 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 (function() {
-    var MESSAGE_CHANNEL_BASE = "AvatarStoreObject";
+    var REMOVED_FROM_PARENT_CHANNEL_BASE = "AvatarStoreRemovedFromParent";
     var CLONE_LIFETIME = 300;
     var UPDATE_INTERVAL = 10000;
 
-    var messageChannel;
+    var removedFromParentChannel;
 
-    var messageHandler;
+    var removedFromParentHandler;
     var spawnMoreChildren;
     var properties;
     var newEntityProperties;
@@ -27,8 +27,8 @@
         remotelyCallable: ['spawnNewEntity'],
         preload: function(entityID){
             properties = Entities.getEntityProperties(entityID, ['dimensions', 'userData', 'modelURL']);
-            messageChannel = MESSAGE_CHANNEL_BASE + entityID;
-            Messages.subscribe(messageChannel);
+            removedFromParentChannel = REMOVED_FROM_PARENT_CHANNEL_BASE + entityID;
+            Messages.subscribe(removedFromParentChannel);
             newEntityProperties = {
                 type: 'Model',
                 dimensions: properties.dimensions,
@@ -43,12 +43,12 @@
                 collidesWith: "dynamic,"
 
             };
-            messageHandler = function(channel, data, sender) {
-                if (channel === messageChannel) {
+            removedFromParentHandler = function(channel, data, sender) {
+                if (channel === removedFromParentChannel) {
                     Entities.addEntity(newEntityProperties);
                 }    
             };
-            Messages.messageReceived.connect(messageHandler);
+            Messages.messageReceived.connect(removedFromParentHandler);
             spawnMoreChildren = Script.setInterval(function() {
                 if (Entities.getChildrenIDs(entityID).length === 0) {
                     Entities.addEntity(newEntityProperties);
@@ -64,7 +64,7 @@
             Entities.addEntity(newEntityProperties);
         },
         unload: function() {
-            Messages.messageReceived.disconnect(messageHandler);
+            Messages.messageReceived.disconnect(removedFromParentHandler);
             Script.clearInterval(spawnMoreChildren);
         }
     };


### PR DESCRIPTION
Test Plan:
-Use the monster beanie in dev-content A&J (it has the raw git scripts from this PR)
-Grab a wearable and immediately let go of it next to it's parent (should destroy)
-Grab a wearable and place it somewhere else away from the avatar and parent (should not destroy), and then grab it again and place it back on the parent (should destroy)
-Grab a wearable and place it on your avatar, then grab it again and place it back on the parent (should destroy)
-Grab a wearable and place it on your avatar, then have another Interface client log in that wasn't in world when you originally grabbed the wearable, and have that client's avatar grab it and place it back on the parent (should destroy)