### PR TITLE
Fix checkout qml

### DIFF
--- a/DomainContent/AvatarStore/CheckoutZone/checkoutZone.js
+++ b/DomainContent/AvatarStore/CheckoutZone/checkoutZone.js
@@ -29,7 +29,7 @@
     
     var TABLET = Tablet.getTablet("com.highfidelity.interface.tablet.system");
     var TABLET_ROTATIONAL_OFFSET = { x: 10, y: 220, z: 0 };
-    var MARKETPLACE_WALLET_QML_PATH = Script.resourcesPath() + "qml/hifi/commerce/wallet/Wallet.qml";
+    var MARKETPLACE_WALLET_QML_PATH = "qml/hifi/commerce/wallet/Wallet.qml";
     // Milliseconds
     var TRANSLATION_CHECK_INTERVAL = 100;
     var SHORTER_STOP_TIMEOUT = 1000;

--- a/DomainContent/AvatarStore/CheckoutZone/checkoutZone.js
+++ b/DomainContent/AvatarStore/CheckoutZone/checkoutZone.js
@@ -29,7 +29,7 @@
     
     var TABLET = Tablet.getTablet("com.highfidelity.interface.tablet.system");
     var TABLET_ROTATIONAL_OFFSET = { x: 10, y: 220, z: 0 };
-    var MARKETPLACE_WALLET_QML_PATH = "qml/hifi/commerce/wallet/Wallet.qml";
+    var MARKETPLACE_WALLET_QML_PATH = "hifi/commerce/wallet/Wallet.qml";
     // Milliseconds
     var TRANSLATION_CHECK_INTERVAL = 100;
     var SHORTER_STOP_TIMEOUT = 1000;


### PR DESCRIPTION
Test plan: 
(Stable) Join 'AvatarIsland' domain
Go to checkout station in 'Regalia' - second from the left (HMD)
Tablet should appear
Ensure it doesn't show empty blue screen but instead shows one of the following (dependently on whether wallet was configured or not, you are logged in or not etc. ):

- prompt to set up wallet
- purple check out instruction page