### PR TITLE
Update camera app to use new protocolSignature API function

### DIFF
--- a/Marketplace/camera-move/app-camera-move.js
+++ b/Marketplace/camera-move/app-camera-move.js
@@ -133,7 +133,7 @@ var DEBUG_INFO = {
     Reticle: {
         supportsScale: 'scale' in Reticle,
     },
-    protocolVersion: location.protocolVersion,
+    protocolVersion: Window.protocolSignature,
 };
 
 var globalState = {

--- a/Marketplace/camera-move/modules/custom-settings-app/CustomSettingsApp.js
+++ b/Marketplace/camera-move/modules/custom-settings-app/CustomSettingsApp.js
@@ -52,7 +52,7 @@ function CustomSettingsApp(options) {
 
     this.extraParams = Object.assign(options.extraParams || {}, {
         customSettingsVersion: CustomSettingsApp.version+'',
-        protocolVersion: location.protocolVersion && location.protocolVersion()
+        protocolVersion: Window.protocolSignature && Window.protocolSignature()
     });
 
     var params = {


### PR DESCRIPTION
Use Window.protocolSignature() in place of the deprecated location.protocolVersion().