### PR TITLE
WL #21772 - Show Display Name when I point at someone

### DIFF
--- a/Marketplace/displayNames/displayNames.js
+++ b/Marketplace/displayNames/displayNames.js
@@ -1,0 +1,115 @@
+//  
+//  displayNames.js
+//  A Desktop/HMD application for displaying nametags above avatars.
+//   
+//  Author: Cain Kilgore
+//  Copyright High Fidelity 2018
+//  
+//  Licensed under the Apache 2.0 License
+//  See accompanying license file or http://apache.org/
+//  
+//  All assets are under CC Attribution Non-Commerical
+//  http://creativecommons.org/licenses/
+//  
+
+(function() {
+    var overlaysCreated = [];
+    var avatarsWithOverlays = [];
+    var howLongWillNameTagAppear = 5; // seconds
+    
+    var nameTagProperties = {
+        type: "text3d",
+        visible: true,
+        text: "N/A",
+        lineHeight: 0.1,
+        topMargin: 0.05,
+        dimensions: { x: 1, y: 0.2, z: 1 },
+        position: {},
+        parentID: {},
+        isFacingAvatar: true,
+    }
+
+    var pointer = Pointers.createPointer(PickType.Ray, {
+        joint: "Mouse",
+        filter: Picks.PICK_AVATARS,
+        distanceScaleEnd: true,
+        hover: false,
+        enabled: true
+    });
+
+    var pointerLeftHand = Pointers.createPointer(PickType.Ray, {
+        joint: "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND",
+        filter: Picks.PICK_AVATARS,
+        distanceScaleEnd: true,
+        hover: false,
+        enabled: true
+    });
+    
+    var pointerRightHand = Pointers.createPointer(PickType.Ray, {
+        joint: "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND",
+        filter: Picks.PICK_AVATARS,
+        distanceScaleEnd: true,
+        hover: false,
+        enabled: true
+    });
+    
+    
+    var mapping_name = "nameTagSelector";
+
+    var mapping = Controller.newMapping(mapping_name);
+    mapping.from(Controller.Hardware.Keyboard.LeftMouseButton).to(function(value) {
+        var res = Pointers.getPrevPickResult(pointer);
+        if(typeof res.objectID == "string") {
+            if(!(avatarsWithOverlays.indexOf(res.objectID) != -1)) {
+                clickOnEntity(res.objectID);
+            }
+        }
+    });
+    mapping.from(Controller.Standard.RT).to(function(value) {
+        var res = Pointers.getPrevPickResult(pointerRightHand);
+        if(typeof res.objectID == "string") {
+            if(!(avatarsWithOverlays.indexOf(res.objectID) != -1)) {
+                clickOnEntity(res.objectID);
+            }
+        }
+    });
+    mapping.from(Controller.Standard.LT).to(function(value) {
+        // alert("yay");
+        var res = Pointers.getPrevPickResult(pointerLeftHand);
+        if(typeof res.objectID == "string") {
+            if(!(avatarsWithOverlays.indexOf(res.objectID) != -1)) {
+                clickOnEntity(res.objectID);
+            }
+        }
+    });
+
+    function clickOnEntity(entityClicked) {
+        var getAvatarClicked = AvatarList.getAvatar(entityClicked);
+        var entityPosition = getAvatarClicked.position;
+        var displayUsername = getAvatarClicked.sessionDisplayName;
+        
+        nameTagProperties.parentID = entityClicked;
+        nameTagProperties.position = Vec3.sum(entityPosition, { x: 0, y: 1, z: 0 });
+        nameTagProperties.text = getAvatarClicked.sessionDisplayName;
+        nameTagProperties.dimensions = { x: displayUsername.length / 12, y: 0.2, z: 1 };
+        
+        var createOverlay = overlaysCreated.push(overlaysCreated, Overlays.addOverlay("text3d", nameTagProperties));
+        avatarsWithOverlays.push(entityClicked);
+        
+        Script.setTimeout(function() {
+            Overlays.deleteOverlay(overlaysCreated[createOverlay-1]);
+            const index = avatarsWithOverlays.indexOf(entityClicked);
+            avatarsWithOverlays.splice(index, 1);
+        }, howLongWillNameTagAppear * 1000);
+    }
+
+    function scriptFinished() {
+        for(var i = 0; i < overlaysCreated.length; i++) {
+            Overlays.deleteOverlay(overlaysCreated[i]);
+        }
+        Controller.disableMapping(mapping_name);
+    }
+    
+    Controller.enableMapping(mapping_name);
+    Script.scriptEnding.connect(scriptFinished);
+}());


### PR DESCRIPTION
> Write a client script that can serve as a replacement to the current nametags script that shows display names over heads. Instead, when I am in the HMD, make it so that if I have my laser activated and point at another avatar, I see their nametag appear over their head for 5 seconds and then disappear. For desktop use, make clicking on the avatar do the same.
> [Worklist 21772](https://worklist.net/21772)

## Test Plan
1. Run the script from this Pull Request ([displayNames.js](https://raw.githubusercontent.com/cain-kilgore/hifi-content/cea7c44e9165b66133ea58ff13503fc719c620b4/Marketplace/displayNames/displayNames.js))
2. In Desktop, click on an Avatar and a nametag should appear above their head and follow them around. The nametag should exist for no longer than 5 seconds.
3. in HMD, hover over an Avatar using your lasers and a nametag should appear above their head and follow them around. The nametag should exist for no longer than 5 seconds.
4. Confirm that you can't click on them over and over, resulting in multiple nametags being created and the nametag taking longer to disappear.
5. Confirming that stopping the script prematurely deletes any existing Nametags which are above an Avatar's head.