### PR TITLE
Update .eslintrc.js to include console

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ module.exports = {
         "keyword-spacing": ["error", { "before": true, "after": true }],
         "max-len": ["error", 128, 4],
         "new-cap": ["error"],
-        'no-console': 'off',
+        "no-console": "off",
         "no-floating-decimal": ["error"],
         //"no-magic-numbers": ["error", { "ignore": [0, 1], "ignoreArrayIndexes": true }],
         "no-multiple-empty-lines": ["error"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
         "WebWindow": false,
         "Window": false,
         "XMLHttpRequest": false,
+        "console": false,
         "location": false,
         "print": false
     },
@@ -66,6 +67,7 @@ module.exports = {
         "keyword-spacing": ["error", { "before": true, "after": true }],
         "max-len": ["error", 128, 4],
         "new-cap": ["error"],
+        'no-console': 'off',
         "no-floating-decimal": ["error"],
         //"no-magic-numbers": ["error", { "ignore": [0, 1], "ignoreArrayIndexes": true }],
         "no-multiple-empty-lines": ["error"],


### PR DESCRIPTION
Added console support (console.debug/warning/etc)

To test, just load up your favorite IDE with ESLINT support and check to see if it complains about console.debug(""); This is just a revision since we added console.debug/warning/etc to the scripting API.