### PR TITLE
Removed broken effects, added spectator camera support to pill

### DIFF
--- a/DomainContent/Hub/pill/scripts/swallowFXPill.js
+++ b/DomainContent/Hub/pill/scripts/swallowFXPill.js
@@ -43,9 +43,7 @@
         3, // Normal
         5, // Metallic
         6, // Emissive
-        16, // Shadow Cascade Indices
-        23, // Low Normal
-        27 // Ambient Occlusion Blurred
+        23 // Low Normal
     ];
 
     var SWALLOW_VOLUME = 0.5;
@@ -76,6 +74,10 @@
             Render.getConfig("RenderMainView").getConfig(WIREFRAME.split(":")[1])[WIREFRAME.split(":")[2]] = false;
             Render.getConfig("RenderMainView").getConfig("DebugDeferredBuffer").mode = 0;
             Render.getConfig("RenderMainView").getConfig("DebugDeferredBuffer").enabled = false;
+
+            Render.getConfig("SecondaryCameraJob").getConfig(WIREFRAME.split(":")[1])[WIREFRAME.split(":")[2]] = false;
+            Render.getConfig("SecondaryCameraJob").getConfig("DebugDeferredBuffer").mode = 0;
+            Render.getConfig("SecondaryCameraJob").getConfig("DebugDeferredBuffer").enabled = false;
         },
 
         removeInjector: function() {
@@ -139,11 +141,16 @@
                 print("effect is: " + effect);
             }
             Render.getConfig("RenderMainView").getConfig("DebugDeferredBuffer").size = {x: -1, y: -1, z: 1, w: 1};
+            Render.getConfig("SecondaryCameraJob").getConfig("DebugDeferredBuffer").size = {x: -1, y: -1, z: 1, w: 1};
             if (effect === WIREFRAME) {
                 Render.getConfig("RenderMainView").getConfig(effect.split(":")[1])[effect.split(":")[2]] = true;
+                Render.getConfig("SecondaryCameraJob").getConfig(effect.split(":")[1])[effect.split(":")[2]] = true;
             } else {
                 Render.getConfig("RenderMainView").getConfig("DebugDeferredBuffer").enabled = true;
                 Render.getConfig("RenderMainView").getConfig("DebugDeferredBuffer").mode = effect;
+
+                Render.getConfig("SecondaryCameraJob").getConfig("DebugDeferredBuffer").enabled = true;
+                Render.getConfig("SecondaryCameraJob").getConfig("DebugDeferredBuffer").mode = effect;
             }
         },
 
@@ -222,6 +229,7 @@
             if (_entityID === Settings.getValue(LAST_ACTIVE_PILL_SETTING, Uuid.NULL)) {
                 _this.resetRenderDefaults();
                 Render.getConfig("RenderMainView").getConfig("DebugDeferredBuffer").size = {x: 0, y: -1, z: 1, w: 1};
+                Render.getConfig("SecondaryCameraJob").getConfig("DebugDeferredBuffer").size = {x: 0, y: -1, z: 1, w: 1};
                 _this.removeInjector();
             }
         }


### PR DESCRIPTION
## Test plan
1. Go to hifi://limitless/-27.7308,-10.2309,-19.9873/0,0.725459,0,0.688265
2. Download the Spectator Camera from Marketplace
3. Start recording with the camera
4. Take some pills
5. Check that the recording also displays the pill effects you took