### PR TITLE
changed key bindings for avatar facial expressions

### DIFF
--- a/Prototyping/FacialExpressions/facialExpressions.js
+++ b/Prototyping/FacialExpressions/facialExpressions.js
@@ -307,37 +307,37 @@
     controllerMappingName = 'Hifi-FacialExpressions-Mapping';
     controllerMapping = Controller.newMapping(controllerMappingName);
 
-    controllerMapping.from(Controller.Hardware.Keyboard.I).to(function(value) {
+    controllerMapping.from(Controller.Hardware.Keyboard.H).to(function(value) {
         if (value !== 0) {
             setEmotion(SMILE);
         }
     });
 
-    controllerMapping.from(Controller.Hardware.Keyboard.O).to(function(value) {
+    controllerMapping.from(Controller.Hardware.Keyboard.J).to(function(value) {
         if (value !== 0) {
             setEmotion(LAUGH);
         }
     });
 
-    controllerMapping.from(Controller.Hardware.Keyboard.P).to(function(value) {
+    controllerMapping.from(Controller.Hardware.Keyboard.K).to(function(value) {
         if (value !== 0) {
             setEmotion(FLIRT);
         }
     });
 
-    controllerMapping.from(Controller.Hardware.Keyboard.J).to(function(value) {
+    controllerMapping.from(Controller.Hardware.Keyboard.L).to(function(value) {
         if (value !== 0) {
             setEmotion(SAD);
         }
     });
 
-    controllerMapping.from(Controller.Hardware.Keyboard.K).to(function(value) {
+    controllerMapping.from(Controller.Hardware.Keyboard.V).to(function(value) {
         if (value !== 0) {
             setEmotion(ANGRY);
         }
     });
 
-    controllerMapping.from(Controller.Hardware.Keyboard.L).to(function(value) {
+    controllerMapping.from(Controller.Hardware.Keyboard.B).to(function(value) {
         if (value !== 0) {
             setEmotion(FEAR);
         }


### PR DESCRIPTION
Script link: https://hifi-content.s3.amazonaws.com/elisalj/facial_expressions/facialExpressions.js
Works best with the Artemis avatar

## Test Plan

1. Load the script, check that the "Emotions" button is active
2. Switch into mirror mode (Ctrl + H)
3. Test out different emotions with these hotkeys:
'H' = smile
'J' = laugh
'K' = flirt
'L = sad
'V' = angry
'B' = fear
'M' = disgust
'N' = neutral

### Known Issues

1. Blendshapes are local changes only; other users cannot see your emotions yet (addressed in https://github.com/highfidelity/hifi/pull/12584)
2. If the script is unloaded while an emotion is activated, the avatar's face will get stuck in that emotion