### PR TITLE
Hub Pill comment typo (re-fix)

### DIFF
--- a/DomainContent/Hub/pill/scripts/swallowFXPill.js
+++ b/DomainContent/Hub/pill/scripts/swallowFXPill.js
@@ -41,7 +41,7 @@
         2, // Albedo
         3, // Normal
         5, // Metallic
-        6, // Emmissive
+        6, // Emissive
         17, // Linear Depth
         23 // Low Normal
     ];


### PR DESCRIPTION
Emissive seems to be a word that's not handled by all spellcheckers

No QA-Required, unless you are sure that Emissive isn't spelled like this.