### PR TITLE
Korea lock instruments

### DIFF
--- a/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
+++ b/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
@@ -14,7 +14,7 @@
 
 (function () {
 
-    var ALLOWED_USERS = ['Firebird25', 'Alan_', 'jyoum', 'tinydancer', 'MissLiviRose'];
+    var ALLOWED_USERS = ["Firebird25", "Alan_", "jyoum", "tinydancer", "MissLiviRose"];
 
     var isAllowedUser = false;
 
@@ -29,11 +29,14 @@
     var isGrabbable = false;
     var SEARCH_RADIUS = 20;
     var timeOutSet = false;
+    
+    var HALF = 0.5;
+    var ONE_AND_HALF = 1.5;
 
     var checkHandInterval = null;
 
     function getEntityListByName(name) {
-        var properties = Entities.getEntityProperties(entityID, 'position');
+        var properties = Entities.getEntityProperties(entityID, "position");
         var entityIDs = Entities.findEntitiesByName(name, properties.position, SEARCH_RADIUS);
         return entityIDs;
     }
@@ -65,16 +68,16 @@
     function isColliding(vector3) {
         // does not factor in rotation
 
-        var properties = Entities.getEntityProperties(entityID, ['position', 'dimensions']);
+        var properties = Entities.getEntityProperties(entityID, ["position", "dimensions"]);
         var dimensions = properties.dimensions;
         var position = properties.position;
 
-        var minX = position.x - dimensions.x / 2;
-        var maxX = position.x + dimensions.x / 2;
-        var minY = position.y + dimensions.y / 2;
-        var maxY = position.y + dimensions.y * 1.5;
-        var minZ = position.z - dimensions.z / 2;
-        var maxZ = position.z + dimensions.z / 2;
+        var minX = position.x - dimensions.x * HALF;
+        var maxX = position.x + dimensions.x * HALF;
+        var minY = position.y + dimensions.y * HALF;
+        var maxY = position.y + dimensions.y * ONE_AND_HALF;
+        var minZ = position.z - dimensions.z * HALF;
+        var maxZ = position.z + dimensions.z * HALF;
 
         if (vector3.x >= minX && vector3.x <= maxX
             && vector3.y >= minY && vector3.y <= maxY
@@ -134,7 +137,7 @@
             if (isAllowedUser) {
                 checkHandInterval = Script.setInterval(function () {
 
-                    var properties = Entities.getEntityProperties(entityID, 'position');
+                    var properties = Entities.getEntityProperties(entityID, "position");
 
                     if (Vec3.distance(MyAvatar.position, properties.position) < 5) {
                         var leftHandIndex = MyAvatar.getJointIndex("LeftHandIndex3");

--- a/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
+++ b/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
@@ -25,9 +25,12 @@
     var LAMP_ON_MODEL_URL = "https://hifi-content.s3.amazonaws.com/jimi/environment/2018_Korea/tableLantern.fbx";
     var LAMP_OFF_MODEL_URL = "https://hifi-content.s3.amazonaws.com/jimi/environment/2018_Korea/tableLantern_off.fbx";
 
+    var SEARCH_RADIUS = 20; // m
+    var IS_TOGGLEABLE_TIMEOUT = 2000; // ms
+    var CHECK_INTERVAL = 50; // ms
+
     var entityID;
     var isGrabbable = false;
-    var SEARCH_RADIUS = 20;
     var timeOutSet = false;
     
     var HALF = 0.5;
@@ -152,11 +155,11 @@
                             timeOutSet = true;
                             Script.setTimeout(function() {
                                 timeOutSet = false;
-                            }, 2000);
+                            }, IS_TOGGLEABLE_TIMEOUT);
                         }
                     }
 
-                }, 50);
+                }, CHECK_INTERVAL);
             }
         },
 

--- a/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
+++ b/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
@@ -6,8 +6,11 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-//  Using entity names, can edit the 
-//
+//  Toggles the korean instruments from from grabbable to ungrabbable with a mouse click
+//  or swiping hand above the lantern entity. Lanterns and lights toggle on and off to 
+//  indicate which grabbable state the instruments are in.
+
+/* global AccountServices */
 
 (function () {
 

--- a/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
+++ b/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
@@ -1,0 +1,171 @@
+// instrumentSwitch.js
+//
+//  Created by Robin Wilson on 7/17/18.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+//  Using entity names, can edit the 
+//
+
+(function () {
+
+    var ALLOWED_USERS = ['Firebird25', 'Alan_', 'jyoum', 'tinydancer', 'MissLiviRose'];
+
+    var isAllowedUser = false;
+
+    var INSTRUMENT_NAME = "InstrumentCloneable";
+    var LIGHT_NAME = "InstrumentLight";
+    var LAMP_NAME = "InstrumentLamp";
+
+    var LAMP_ON_MODEL_URL = "https://hifi-content.s3.amazonaws.com/jimi/environment/2018_Korea/tableLantern.fbx";
+    var LAMP_OFF_MODEL_URL = "https://hifi-content.s3.amazonaws.com/jimi/environment/2018_Korea/tableLantern_off.fbx";
+
+    var entityID;
+    var isGrabbable = false;
+    var SEARCH_RADIUS = 20;
+    var timeOutSet = false;
+
+    var checkHandInterval = null;
+
+    function getEntityListByName(name) {
+        var properties = Entities.getEntityProperties(entityID, 'position');
+        var entityIDs = Entities.findEntitiesByName(name, properties.position, SEARCH_RADIUS);
+        return entityIDs;
+    }
+
+    function setGrabbable(id, isGrabbable) {
+        Entities.editEntity(id, {
+            cloneable: isGrabbable,
+            userData: JSON.stringify({
+                "grabbableKey": {
+                    "grabbable": isGrabbable
+                }
+            })
+        });
+    }
+
+    function setLampModel(id, isOn) {
+        var nextLampModel = isOn ? LAMP_ON_MODEL_URL : LAMP_OFF_MODEL_URL;
+        Entities.editEntity(id, {
+            modelURL: nextLampModel
+        });
+    }
+
+    function setLightOn(id, isOn) {
+        Entities.editEntity(id, {
+            visible: isOn
+        });
+    }
+
+    function isColliding(vector3) {
+        // does not factor in rotation
+
+        var properties = Entities.getEntityProperties(entityID, ['position', 'dimensions']);
+        var dimensions = properties.dimensions;
+        var position = properties.position;
+
+        var minX = position.x - dimensions.x / 2;
+        var maxX = position.x + dimensions.x / 2;
+        var minY = position.y + dimensions.y / 2;
+        var maxY = position.y + dimensions.y * 1.5;
+        var minZ = position.z - dimensions.z / 2;
+        var maxZ = position.z + dimensions.z / 2;
+
+        if (vector3.x >= minX && vector3.x <= maxX
+            && vector3.y >= minY && vector3.y <= maxY
+            && vector3.z >= minZ && vector3.z <= maxZ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function toggleInstrumentGrabbable() {
+
+        if (ALLOWED_USERS.indexOf(AccountServices.username) >= 0) {
+            var instrumentList = getEntityListByName(INSTRUMENT_NAME);
+            var lampList = getEntityListByName(LAMP_NAME);
+            var lightList = getEntityListByName(LIGHT_NAME);
+
+            if (instrumentList.length > 0) {
+
+                var properties = Entities.getEntityProperties(entityID, "modelURL");
+                if (properties.modelURL && properties.modelURL === LAMP_ON_MODEL_URL) {
+                    isGrabbable = false;
+                } else {
+                    isGrabbable = true;
+                }
+
+            }
+
+            instrumentList.forEach(function (instrumentID) {
+                setGrabbable(instrumentID, isGrabbable);
+            });
+
+            lampList.forEach(function (lampID) {
+                setLampModel(lampID, isGrabbable);
+            });
+
+            lightList.forEach(function (lightID) {
+                setLightOn(lightID, isGrabbable);
+            });
+
+        }
+    }
+
+
+    var InstrumentSwitch = function () {
+
+    };
+
+    InstrumentSwitch.prototype = {
+
+        preload: function (id) {
+
+            entityID = id;
+
+            isAllowedUser = ALLOWED_USERS.indexOf(AccountServices.username) >= 0;
+
+            if (isAllowedUser) {
+                checkHandInterval = Script.setInterval(function () {
+
+                    var properties = Entities.getEntityProperties(entityID, 'position');
+
+                    if (Vec3.distance(MyAvatar.position, properties.position) < 5) {
+                        var leftHandIndex = MyAvatar.getJointIndex("LeftHandIndex3");
+                        var rightHandIndex = MyAvatar.getJointIndex("RightHandIndex3");
+
+                        var leftPosition = MyAvatar.getJointPosition(leftHandIndex);
+                        var rightPosition = MyAvatar.getJointPosition(rightHandIndex); 
+
+                        var hasCollision = isColliding(leftPosition) || isColliding(rightPosition);
+                        if (hasCollision && !timeOutSet) {
+                            toggleInstrumentGrabbable();
+                            timeOutSet = true;
+                            Script.setTimeout(function() {
+                                timeOutSet = false;
+                            }, 2000);
+                        }
+                    }
+
+                }, 50);
+            }
+        },
+
+        mousePressOnEntity: function (entityID, mouseEvent) {
+            toggleInstrumentGrabbable();
+        },
+
+        unload: function () {
+            if (checkHandInterval) {
+                Script.clearInterval(checkHandInterval);
+            }
+        }
+
+    };
+
+    return new InstrumentSwitch();
+
+});

--- a/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
+++ b/Prototyping/Domains/Korea/InstrumentSwitch/instrumentSwitch.js
@@ -28,6 +28,7 @@
     var SEARCH_RADIUS = 20; // m
     var IS_TOGGLEABLE_TIMEOUT = 2000; // ms
     var CHECK_INTERVAL = 50; // ms
+    var MIN_DISTANCE_CHECK = 5; // Minimum distance to start checking avatar hand positions
 
     var entityID;
     var isGrabbable = false;
@@ -142,7 +143,7 @@
 
                     var properties = Entities.getEntityProperties(entityID, "position");
 
-                    if (Vec3.distance(MyAvatar.position, properties.position) < 5) {
+                    if (Vec3.distance(MyAvatar.position, properties.position) < MIN_DISTANCE_CHECK) {
                         var leftHandIndex = MyAvatar.getJointIndex("LeftHandIndex3");
                         var rightHandIndex = MyAvatar.getJointIndex("RightHandIndex3");
 


### PR DESCRIPTION
In a room with korea instruments, the guide can swipe a hand over "the master lantern" to unlock instruments in the room. The "instrument lanterns" will light up when the music instruments are grabbable and be off when they are locked, mirroring the lit state of the master lantern.

**Setup and Normal Use Case**
1. Go to "hifi://korea"
2. To to the Music room. The "master lantern" is next to the "MUSIC" sign in the back of the room
3. Ensure you're on the script hard-coded white list **_-- please comment on this PR with your hifi username if you need to be added to the whitelist for the Korea domain AND/OR the script_**
4. Check the instruments:
    - If the lights around the room are off, check that the instruments are locked.
    - If lights are on, check that instruments are grabbable and play music.
6. Swipe over the "master lantern," the lights will switch states from on to off or from off to on, the lanterns near the instruments will mirror the master lantern.
7. Check the instruments:
    - If the lights around the room are off, check that the instruments are locked.
    - If lights are on, check that instruments are grabbable and play music.

**Specific Cases to ensure are always true**
- Instrument lights always match the master lantern state.
- All music making Instruments are:
            - Locked when lights are off
            - Grabbable when lights are on
- Only people on the instrument whitelist are able to toggle the master lantern