### PR TITLE
GrabbableLifetime utility for cloneable grabbbable objects

### DIFF
--- a/Prototyping/Domains/Korea/Instruments/InstrumentClone.js
+++ b/Prototyping/Domains/Korea/Instruments/InstrumentClone.js
@@ -50,7 +50,7 @@ InstrumentClone.prototype = {
         this.handNum = 0;
 
         Script.setTimeout(function(){
-            if(entityProperties.name && entityProperties.name.indexOf("clone") !== -1){
+            if (entityProperties.name && entityProperties.name.indexOf("clone") !== -1){
                 if (DEBUG) {
                     print("Instrument clone: preload edit lifetime ", entityProperties.name);
                 }

--- a/Utilities/Entities/GrabbableLifetime.js
+++ b/Utilities/Entities/GrabbableLifetime.js
@@ -1,0 +1,92 @@
+// GrabbableLifetime.js
+//
+// Copyright 2018 High Fidelity, Inc.
+// Created by Robin Wilson 7/5/2018
+//
+// Set this script on a spawner for cloneable grabbable entities.
+// Will set clone lifetime on pickup and on release to default values
+// or by user specified values in userData.
+// 
+// To customize, add below property to userData object:
+// 
+// "lifetimeOnGrab": {
+//     "pickup": <INT SECONDS> ,
+//     "release": <INT SECONDS> 
+// }
+//
+// Distributed under the Apache License, Version 2.0.
+// See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+(function () {
+
+    var LIFETIME_ON_PICKUP = 18;
+    var LIFETIME_ON_RELEASE = 8;
+    var PROPERTY_NAME = "lifetimeOnGrab";
+    var DEBUG = true;
+
+    function GrabbableLifetime() {
+        this.entityID;
+        this.pickupLifetime = LIFETIME_ON_PICKUP;
+        this.releaseLifetime = LIFETIME_ON_RELEASE;
+    }
+
+    GrabbableLifetime.prototype = {
+
+        preload: function (entityID) {
+
+            this.entityID = entityID;
+            var properties = Entities.getEntityProperties(this.entityID, ["name", "age", "userData"]);
+            
+            try {
+
+                var userData = JSON.parse(properties.userData);
+                print(JSON.stringify(userData));
+                
+                if (userData && userData[PROPERTY_NAME]) {
+                    this.pickupLifetime = userData[PROPERTY_NAME].pickup || LIFETIME_ON_PICKUP;
+                    this.releaseLifetime = userData[PROPERTY_NAME].release || LIFETIME_ON_RELEASE;
+                }
+                
+            } catch (error) {
+                console.error("Error parsing userData :", error);
+            }
+            
+            if (properties.name && properties.name.indexOf("clone") !== -1){
+                this.setAge(this.pickupLifetime, "preload");
+            }
+
+        },
+
+        startNearGrab: function () {
+            this.setAge(this.pickupLifetime, "startNearGrab");
+        },
+
+        releaseGrab: function () {
+            this.setAge(this.releaseLifetime, "releaseGrab");
+        },
+
+        setAge: function(secondsToDespawn, functionName) {
+
+            if (DEBUG) {
+                this.printDebug("Start " + functionName);
+            }
+
+            var currentAge = Entities.getEntityProperties(this.entityID, "age").age;
+            Entities.editEntity(this.entityID, { lifetime: currentAge + secondsToDespawn });
+        
+            if (DEBUG) {
+                this.printDebug("End " + functionName);
+            }
+
+        },
+
+        printDebug: function (message) {
+            var debugProperties = Entities.getEntityProperties(this.entityID, ["lifetime"]);
+            print(message + debugProperties.lifetime);
+        }
+
+    };
+
+    return new GrabbableLifetime();
+
+});

--- a/Utilities/Entities/GrabbableLifetime.js
+++ b/Utilities/Entities/GrabbableLifetime.js
@@ -40,7 +40,6 @@
             try {
 
                 var userData = JSON.parse(properties.userData);
-                print(JSON.stringify(userData));
                 
                 if (userData && userData[PROPERTY_NAME]) {
                     this.pickupLifetime = userData[PROPERTY_NAME].pickup || LIFETIME_ON_PICKUP;
@@ -51,9 +50,8 @@
                 console.error("Error parsing userData :", error);
             }
             
-            if (properties.name && properties.name.indexOf("clone") !== -1){
-                this.setAge(this.pickupLifetime, "preload");
-            }
+            // checks if clone inside this.setAge()
+            this.setAge(this.pickupLifetime, "preload");
 
         },
 
@@ -65,14 +63,21 @@
             this.setAge(this.releaseLifetime, "releaseGrab");
         },
 
+        isClone: function () {
+            var name = Entities.getEntityProperties(this.entityID, ["name"]).name;
+            return name && name.indexOf("clone") !== -1;
+        },
+
         setAge: function(secondsToDespawn, functionName) {
 
             if (DEBUG) {
                 this.printDebug("Start " + functionName);
             }
-
-            var currentAge = Entities.getEntityProperties(this.entityID, "age").age;
-            Entities.editEntity(this.entityID, { lifetime: currentAge + secondsToDespawn });
+            
+            if (this.isClone()) {
+                var currentAge = Entities.getEntityProperties(this.entityID, "age").age;
+                Entities.editEntity(this.entityID, { lifetime: currentAge + secondsToDespawn });
+            }
         
             if (DEBUG) {
                 this.printDebug("End " + functionName);


### PR DESCRIPTION
For cloneable grabbable objects, changes the clone's lifetime on pickup and on release. After the userData specified or default values on release or on pickup of the clone, the clone despawns.

Test Plan

**Setup Default Values**
1. Create cube. Make grabble and cloneable. Lifetime of -1.
2. Add script to the cube.

**Test default values**
1. Use Cube from "Setup Default Values"
2. In HMD, pick up cube. 
3. Test pickup lifetime: Hold on to the cube for 18 seconds. After 18 secs, should despawn.
4. Test release lifetime: Pickup then let go of cube for 8 seconds. After 8 secs, should despawn.
^^ Pickup and release cube intermittently. After **any release** should always despawn after 8 secs. After **any pickup** should always despawn after 18 secs. 


**Setup Custom userData Values**
1. ^^ Follow setup from top "Setup Default Values"
2. Add below additional property to cube userData: 
"lifetimeOnGrab": {
    "pickup": 5 ,
    "release": 2 
}
3. Refresh the script to register new pickup/release values

**Test user specified values**
1. Use Cube from "Setup Custom userData Values"
2. In HMD, pick up cube. 
3. Test pickup lifetime: Hold on to the cube for 5 seconds. After 5 secs, should despawn.
4. Test release lifetime: Pickup then let go of cube for 2 seconds. After 2 secs, should despawn.
^^ Pickup and release cube intermittently. After **any release** should always despawn after 2 secs. After **any pickup** should always despawn after 5 secs. 