### PR TITLE
Shower Dance Walk Fixes

### DIFF
--- a/DomainContent/Hub/Animation Shower/resetButton.js
+++ b/DomainContent/Hub/Animation Shower/resetButton.js
@@ -11,7 +11,7 @@
 (function() {
     var SOUND_URL = Script.resolvePath("Sounds/undo-notif.wav");
 
-    var walkRoles = ["walkFwd", "idleToWalkFwd", "walkBwdNormal"];
+    var walkRoles = ["walkFwdNormal", "idleToWalkFwd", "walkBwdNormal"];
     var sound = SoundCache.getSound(SOUND_URL);
 
     function resetAnimations() {

--- a/DomainContent/Hub/Animation Shower/shower-script.js
+++ b/DomainContent/Hub/Animation Shower/shower-script.js
@@ -23,7 +23,7 @@
     var AUDIO_VOLUME_LEVEL = 0.5;
     var NUMBER_OF_ANIMATIONS = 6;
 
-    var walkRoles = ["walkFwd", "idleToWalkFwd", "walkBwdNormal"];
+    var walkRoles = ["walkFwdNormal", "idleToWalkFwd", "walkBwdNormal"];
     var Animations = Array();
     var sound;
     var _this;
@@ -58,12 +58,13 @@
             var animationIndex = Math.floor(Math.random()* NUMBER_OF_ANIMATIONS);
             _this.playSound(MyAvatar.position);
             resetAnimations();
+            MyAvatar.overrideRoleAnimation("walkFwdNormal", Animations[animationIndex].url, FPS, true, 0, 
+                Animations[animationIndex].animation.frames.length);
             MyAvatar.overrideRoleAnimation("idleToWalkFwd", Animations[animationIndex].url, FPS, true, 0, 
                 Animations[animationIndex].animation.frames.length);
             MyAvatar.overrideRoleAnimation("walkBwdNormal", Animations[animationIndex].url, -FPS, true, 0, 
                 Animations[animationIndex].animation.frames.length);
         },
-        
         playSound: function(position) {
             if (sound.downloaded) {
                 Audio.playSound(sound, {


### PR DESCRIPTION
This fixes walking through the shower.  The forward walk was broken originally.  
I haven't been able to reproduce avatars being bunched up, so this doesn't address that if it is still an issue.

Test Plan:

- [x] Walk through the shower

- [x] Do you have a new walk animation that is the same but in reverse when you move the opposite direction?

- [x] Press the reset button

- [x] Do you walk normally?

- [x] Repeat the process several times and make sure there aren't any oddities.
