### PR TITLE
Add support for Mikomiko SIM joints and allow one joint threads

### DIFF
--- a/Utilities/HairFlow/readme.md
+++ b/Utilities/HairFlow/readme.md
@@ -9,10 +9,11 @@
 
 ![Flow Thread](https://hifi-content.s3.amazonaws.com/luis/flowFiles/reference/flow.png)
 
-A **Flow Thread** is a set with as least 2 connected joints that comply with the following rules:
+A **Flow Thread** is a set with as least one joint that comply with the following rules:
 
 * The first joint is connected to an existing avatar joint (“Hips” for example).
 * Every “Flow Joint” should be named **flow_[TYPE]_[INDEX]**, where **TYPE** defines a group of joints that share a common physics setup and **INDEX** is an integer. For example, if the thread is used to simulate a skirt, all the “skirt” joints should be named flow_skirt_01, flow_skirt_02, etc.
+* Added support for SIM joints (Mikomiko avatar) with names **sim[TYPE][INDEX]**
 
 ## Display Panel
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18765/Flow-js-doesn-t-support-single-bone-chains
This PR makes possible parsing sim joints from Mikomiko avatars and adds them as flow joints.
It also allows the simulation of threads with only one joint by attaching a dummy joint and adding some stiffness.