### PR TITLE
Update threads length when changing scale

### DIFF
--- a/Utilities/HairFlow/flow.js
+++ b/Utilities/HairFlow/flow.js
@@ -20,70 +20,70 @@ Script.include(Script.resolvePath("./VectorMath.js"));
     var SHOW_DEBUG_SHAPES = false;
     var SHOW_SOLID_SHAPES = false;
     var SHOW_DUMMY_JOINTS = false;
-    var USE_COLLISIONS = false;
-    
+    var USE_COLLISIONS = true;
+
     var HAPTIC_TOUCH_STRENGTH = 0.25;
     var HAPTIC_TOUCH_DURATION = 10.0;
     var HAPTIC_SLOPE = 0.18;
-    
+
     var LEFT_HAND = 0;
     var RIGHT_HAND = 1;
-    
+
     var HAPTIC_THRESHOLD = 40;
-    
+
     var FLOW_JOINT_PREFIX = "flow";
     var SIM_JOINT_PREFIX = "sim";
-    
+
     var JOINT_COLLISION_PREFIX = "joint_";
     var HAND_COLLISION_PREFIX = "hand_";
     var HAND_COLLISION_RADIUS = 0.03;
     var HAND_TOUCHING_DISTANCE = 2.0;
-    
+
     var COLLISION_SHAPES_LIMIT = 4;
-    
+
     var DUMMY_KEYWORD = "Extra";
     var DUMMY_JOINT_COUNT = 8;
     var DUMMY_JOINT_DISTANCE = 0.05;
-    
+
     var ISOLATED_JOINT_STIFFNESS = 0.85;
     var ISOLATED_JOINT_LENGTH = 0.05;
-        
+
     // Joint groups by keyword
 
-    
+
     var FLOW_JOINT_KEYWORDS = [];
     var FLOW_JOINT_DATA = {};
-    
-        
+
+
     var DEFAULT_JOINT_SETTINGS = { "get": function() {
         return {"active": true, "stiffness": 0.0, "gravity": -0.0096 ,"damping": 0.85, "inertia": 0.8, "delta": 0.55, "radius": 0.01};
     }};
-    
+
     var DEFAULT_COLLISION_SETTINGS = {type: "sphere", radius: 0.05, offset: {x: 0, y: 0, z: 0}};
-    
+
     var PRESET_FLOW_DATA = {
-        "hair": {"active": true, "stiffness": 0.0, "gravity": -0.0096 ,"damping": 0.85, "inertia": 0.8, "delta": 0.55, "radius": 0.01}, 
-        "skirt": {"active": true, "stiffness": 0.0, "gravity": -0.0096 ,"damping": 0.85, "inertia": 0.25, "delta": 0.45, "radius": 0.01}, 
+        "hair": {"active": true, "stiffness": 0.0, "gravity": -0.0096 ,"damping": 0.85, "inertia": 0.8, "delta": 0.55, "radius": 0.01},
+        "skirt": {"active": true, "stiffness": 0.0, "gravity": -0.0096 ,"damping": 0.85, "inertia": 0.25, "delta": 0.45, "radius": 0.01},
         "breasts": {"active": true, "stiffness": 1, "gravity": -0.0096 ,"damping": 0.65, "inertia": 0.8, "delta": 0.45, "radius": 0.01}
     };
-    
+
     var PRESET_COLLISION_DATA = {
         "Head": {type: "sphere", radius: 0.08, offset: {x: 0, y: 0.06, z: 0.00}},
         "RightArm": {type: "sphere", radius: 0.05, offset: {x: 0.0, y: 0.02, z: 0.00}},
         "LeftArm": {type: "sphere", radius: 0.05, offset: {x: 0.0, y: 0.02, z: 0.00}},
         "Spine2": {type: "sphere", radius: 0.09, offset: {x: 0, y: 0.04, z: 0.00}}
     };
-        
+
     var CUSTOM_FLOW_DATA, CUSTOM_COLLISION_DATA;
-    
+
     // CUSTOM DATA STARTS HERE
 
 
     CUSTOM_FLOW_DATA = {
         "hair": {
             "active": true,
-            "stiffness": 0.35,
-            "radius": 0.03,
+            "stiffness": 0.0,
+            "radius": 0.04,
             "gravity": -0.035,
             "damping": 0.8,
             "inertia": 0.8,
@@ -94,7 +94,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
     CUSTOM_COLLISION_DATA = {
         "Spine2": {
             "type": "sphere",
-            "radius": 0.11,
+            "radius": 0.14,
             "offset": {
                 "x": 0,
                 "y": 0.2,
@@ -103,7 +103,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         },
         "RightArm": {
             "type": "sphere",
-            "radius": 0.05,
+            "radius": 0.03,
             "offset": {
                 "x": 0,
                 "y": 0.02,
@@ -112,7 +112,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         },
         "LeftArm": {
             "type": "sphere",
-            "radius": 0.05,
+            "radius": 0.03,
             "offset": {
                 "x": 0,
                 "y": 0.02,
@@ -130,16 +130,18 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         }
     };
 
-    
+
     // CUSTOM DATA ENDS HERE
-    
+
     var HAND_COLLISION_JOINTS = ["RightHandMiddle1", "RightHandThumb3", "LeftHandMiddle1", "LeftHandThumb3","RightHandMiddle3", "LeftHandMiddle3"];
-    
+
     if (SHOW_DUMMY_JOINTS) {
         FLOW_JOINT_KEYWORDS.push(DUMMY_KEYWORD);
         FLOW_JOINT_DATA[DUMMY_KEYWORD] = DEFAULT_JOINT_SETTINGS.get();
     }
-    
+
+    var avatarScale = MyAvatar.scale;
+
     var FlowDebug = function() {
         var self = this;
         this.debugLines = {};
@@ -147,7 +149,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.debugCubes = {};
         this.showDebugShapes = false;
         this.showSolidShapes = false;
-        
+
         this.setDebugCube = function(cubeName, cubePosition, cubeRotation, cubeDimensions, shapeColor, forceRendering) {
             var doRender = self.showDebugShapes || forceRendering;
             if (!doRender) return;
@@ -175,7 +177,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 });
             }
         };
-        
+
         this.setDebugLine = function(lineName, startPosition, endPosition, shapeColor, forceRendering) {
             var doRender = self.showDebugShapes || forceRendering;
             if (!doRender) return;
@@ -198,7 +200,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 });
             }
         };
-        
+
         this.setDebugSphere = function(sphereName, pos, diameter, shapeColor, forceRendering) {
             var doRender = self.showDebugShapes || forceRendering;
             if (!doRender) return;
@@ -222,22 +224,22 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 });
             }
         };
-        
+
         this.deleteSphere = function(name) {
             Overlays.deleteOverlay(self.debugSpheres[name]);
             self.debugSpheres[name] = undefined;
         };
-        
+
         this.deleteLine = function(name) {
             Overlays.deleteOverlay(self.debugLines[name]);
             self.debugLines[name] = undefined;
         };
-        
+
         this.deleteCube = function(name) {
             Overlays.deleteOverlay(self.debugCubes[name]);
             self.debugCubes[name] = undefined;
         };
-        
+
         this.cleanup = function() {
             for (var lineName in self.debugLines) {
                 if (lineName !== undefined) {
@@ -258,7 +260,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             self.debugSpheres = {};
             self.debugCubes = {};
         };
-        
+
         this.setVisible = function(isVisible) {
             self.showDebugShapes = isVisible;
             for (var lineName in self.debugLines) {
@@ -276,7 +278,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
         };
-        
+
         this.setSolid = function(isSolid) {
             self.showSolidShapes = isSolid;
             for (var lineName in self.debugLines) {
@@ -293,7 +295,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                     });
                 }
             }
-        };       
+        };
 
     };
 
@@ -311,7 +313,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.isRightHandTouching = false;
         this.rightHandTouchDelta = 0;
         this.rightHandTouchThreshold = 0;
-        
+
         this.getNearbyAvatars = function(distance) {
             return AvatarList.getAvatarIdentifiers().filter(function(avatarID){
                 if (!avatarID) {
@@ -325,7 +327,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 return VEC3.distance(avatarPosition, MyAvatar.position) < distance;
             });
         };
-        
+
         this.setScale = function(scale) {
             for (var j = 0; j < self.avatarHands.length; j++) {
                 for (var i = 0; i < HAND_COLLISION_JOINTS.length; i++) {
@@ -334,11 +336,11 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
         };
-        
+
         this.update = function() {
             var nearbyAvatars = self.getNearbyAvatars(HAND_TOUCHING_DISTANCE);
             nearbyAvatars.push(MyAvatar.SELF_ID);
-            
+
             nearbyAvatars.forEach(function(avatarID) {
 
                 var avatar = AvatarList.getAvatar(avatarID);
@@ -363,7 +365,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                     self.avatarHands[avatarIndex][side].update();
                 }
             });
-            
+
             if (nearbyAvatars.length < self.lastAvatarCount) {
                 var avatarsToUntrack = [];
                 for (var i = 0; i < self.avatarIds.length; i++) {
@@ -380,7 +382,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             }
             self.lastAvatarCount = nearbyAvatars.length;
         };
-        
+
         this.computeCollision = function(collisions) {
             var collisionData = new FlowCollisionData();
             if (collisions.length > 1) {
@@ -388,8 +390,8 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                     collisionData.offset += collisions[i].offset;
                     collisionData.normal = VEC3.sum(collisionData.normal, VEC3.multiply(collisions[i].normal, collisions[i].distance));
                     collisionData.position = VEC3.sum(collisionData.position, collisions[i].position);
-                    collisionData.radius += collisions[i].radius; 
-                    collisionData.distance += collisions[i].distance; 
+                    collisionData.radius += collisions[i].radius;
+                    collisionData.distance += collisions[i].distance;
                 }
                 collisionData.offset = collisionData.offset/collisions.length;
                 collisionData.radius = VEC3.length(collisionData.normal)/2;
@@ -402,7 +404,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             collisionData.collisionCount = collisions.length;
             return collisionData;
         };
-        
+
         this.manageHapticPulse = function() {
             if (self.isLeftHandTouching) {
                 self.leftHandTouchDelta += HAPTIC_SLOPE;
@@ -411,7 +413,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             } else {
                 if (self.leftHandTouchThreshold++ > HAPTIC_THRESHOLD) {
                     self.leftHandTouchDelta = 0;
-                }               
+                }
             }
             if (self.isRightHandTouching) {
                 self.rightHandTouchDelta += HAPTIC_SLOPE;
@@ -423,7 +425,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
         };
-        
+
         this.checkThreadCollisions = function(thread) {
 
             var threadCollisionData = Array(thread.joints.length);
@@ -459,22 +461,22 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                                     threadCollisionData[k].push(segmentCollision);
                                     isTouching = true;
                                 }
-                            }       
-                            
+                            }
+
                             if (isTouching) {
                                 if (side.indexOf("RightHand") > -1) {
                                     self.isRightHandTouching = true;
                                 } else {
                                     self.isLeftHandTouching = true;
                                 }
-                            } 
+                            }
                         }
                     }
                 }
             }
-            
+
             self.manageHapticPulse();
-            
+
             var collisionResult = [];
             for (i = 0; i < thread.joints.length; i++) {
                 collisionResult.push(self.computeCollision(threadCollisionData[i]));
@@ -485,7 +487,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.setRightTriggerValue = function(value) {
             self.rightTriggerValue = value;
         };
-        
+
         this.setLeftTriggerValue = function(value) {
             self.leftTriggerValue = value;
         };
@@ -495,15 +497,15 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         var self = this;
         this.collisionSpheres = [];
         this.collisionCubes = [];
-        
+
         this.addCollisionSphere = function(name, jointIndex, jointName, settings) {
             self.collisionSpheres.push(new FlowCollisionSphere(name, jointIndex, jointName, settings));
         };
-        
+
         this.addCollisionCube = function(name, jointIndex, jointName, settings) {
             self.collisionCubes.push(new FlowCollisionCube(name, jointIndex, jointName, settings));
         };
-        
+
         this.addCollisionShape = function(jointIndex, jointName, settings) {
             var name = JOINT_COLLISION_PREFIX + jointIndex;
             switch(settings.type) {
@@ -515,7 +517,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                     break;
             }
         };
-        
+
         this.addCollisionToJoint = function(jointName) {
             if (self.collisionSpheres.length >= COLLISION_SHAPES_LIMIT) {
                 return false;
@@ -529,7 +531,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 return false;
             }
         };
-        
+
         this.removeCollisionFromJoint = function(jointName) {
             var jointIndex = MyAvatar.getJointIndex(jointName);
             var collisionIndex = self.findCollisionWithJoint(jointIndex);
@@ -538,7 +540,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 self.collisionSpheres.splice(collisionIndex, 1);
             }
         };
-        
+
         this.update = function() {
             for (var i = 0; i < self.collisionCubes.length; i++) {
                 self.collisionCubes[i].update();
@@ -547,16 +549,16 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 self.collisionSpheres[i].update();
             }
         };
-        
+
         this.computeCollision = function(collisions) {
             var collisionData = new FlowCollisionData();
             if (collisions.length > 1) {
                 for (var i = 0; i < collisions.length; i++) {
-                    collisionData.offset += collisions[i].offset; 
+                    collisionData.offset += collisions[i].offset;
                     collisionData.normal = VEC3.sum(collisionData.normal, VEC3.multiply(collisions[i].normal, collisions[i].distance));
                     collisionData.position = VEC3.sum(collisionData.position, collisions[i].position);
                     collisionData.radius += collisions[i].radius;
-                    collisionData.distance += collisions[i].distance; 
+                    collisionData.distance += collisions[i].distance;
                 }
                 collisionData.offset = collisionData.offset/collisions.length;
                 collisionData.radius = VEC3.length(collisionData.normal)/2;
@@ -569,7 +571,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             collisionData.collisionCount = collisions.length;
             return collisionData;
         };
-        
+
         this.setScale = function(scale) {
             for (var j = 0; j < self.collisionSpheres.length; j++) {
                 self.collisionSpheres[j].radius = self.collisionSpheres[j].initialRadius * scale;
@@ -583,7 +585,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 threadCollisionData[i] = [];
             }
             for (var j = 0; j < self.collisionSpheres.length; j++) {
-                
+
                 var rootCollision = self.collisionSpheres[j].checkCollision(thread.positions[0], thread.radius);
                 var collisionData = [rootCollision];
                 var tooFar = rootCollision.distance > (thread.length + rootCollision.radius);
@@ -606,7 +608,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                                     threadCollisionData[i-1].push(segmentCollision);
                                     threadCollisionData[i].push(segmentCollision);
                                 }
-                            }                       
+                            }
                         }
                     } else {
                         if (rootCollision.offset > 0) {
@@ -628,7 +630,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             }
             return collisionResult;
         };
-        
+
         this.findCollisionWithJoint = function (jointIndex) {
             for (var i = 0; i < self.collisionSpheres.length; i++) {
                 if (self.collisionSpheres[i].jointIndex == jointIndex) {
@@ -637,11 +639,10 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             }
             return -1;
         };
-        
+
         this.modifyCollision = function(jointName, parameter, value) {
             var jointIndex = MyAvatar.getJointIndex(jointName);
             var collisionIndex = self.findCollisionWithJoint(jointIndex);
-            var avatarScale = MyAvatar.scale;
             if (collisionIndex > -1) {
                 switch(parameter) {
                     case "radius": {
@@ -658,7 +659,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
         };
-        
+
         this.getCollisionData = function() {
             var collisionData = {};
             for (var i = 0; i < self.collisionSpheres.length; i++) {
@@ -669,7 +670,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         };
 
     };
-    
+
     var FlowCollisionData = function(offset, position, radius, normal, distance) {
         this.collisionCount = 0;
         this.offset = offset !== undefined ? offset : 0;
@@ -678,7 +679,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.normal = normal !== undefined ? normal : {x: 0, y: 0, z: 0};
         this.distance = distance !== undefined ? distance : 0;
     };
-    
+
     var FlowCollisionSphere = function(name, jointIndex, jointName, settings) {
         var self = this;
         this.name = name;
@@ -689,22 +690,22 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.initialOffset = {x: self.offset.x, y: self.offset.y, z: self.offset.z};
         this.attenuation = settings.attenuation;
         this.avatarId = settings.avatarId;
-        
+
         this.position = {x:0, y:0, z:0};
-        
+
         this.update = function() {
             if (self.avatarId !== undefined){
                 var avatar = AvatarList.getAvatar(self.avatarId);
                 self.position = avatar.getJointPosition(self.jointIndex);
             } else {
                 self.position = MyAvatar.jointToWorldPoint(self.offset, self.jointIndex);
-            }               
+            }
             collisionDebug.setDebugSphere(self.name, self.position, 2*self.radius, {red: 200, green: 10, blue: 50});
             if (self.attenuation && self.attenuation > 0) {
-                collisionDebug.setDebugSphere(self.name + "_att", self.position, 2*(self.radius + self.attenuation), {red: 120, green: 200, blue: 50}); 
+                collisionDebug.setDebugSphere(self.name + "_att", self.position, 2*(self.radius + self.attenuation), {red: 120, green: 200, blue: 50});
             }
         };
-        
+
         this.checkCollision = function(point, radius) {
             var centerToJoint = VEC3.subtract(point, self.position);
             var distance = VEC3.length(centerToJoint) - radius;
@@ -712,7 +713,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             var collisionData = new FlowCollisionData(offset, self.position, self.radius, VEC3.normalize(centerToJoint), distance);
             return collisionData;
         };
-        
+
         this.checkSegmentCollision = function(point1, point2, pointCollision1, pointCollision2) {
             var collisionData = new FlowCollisionData();
             var segment = VEC3.subtract(point2, point1);
@@ -720,7 +721,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             var maxDistance = Math.sqrt(Math.pow(pointCollision1.radius,2) + Math.pow(segmentLength,2));
             if (pointCollision1.distance < maxDistance && pointCollision2.distance < maxDistance) {
                 var segmentPercent = pointCollision1.distance/(pointCollision1.distance + pointCollision2.distance);
-                var collisionPoint = VEC3.sum(point1, VEC3.multiply(segment, segmentPercent)); 
+                var collisionPoint = VEC3.sum(point1, VEC3.multiply(segment, segmentPercent));
                 var centerToSegment = VEC3.subtract(collisionPoint, self.position);
                 var distance = VEC3.length(centerToSegment);
                 if (distance < self.radius) {
@@ -730,12 +731,12 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             }
             return collisionData;
         };
-        
+
         this.clean = function() {
             collisionDebug.deleteSphere(self.name);
         };
     };
-    
+
     var FlowCollisionCube = function(name, jointIndex, settings) {
         var self = this;
         this.name = name;
@@ -744,33 +745,33 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.offset = settings.offset;
         this.attenuation = settings.attenuation;
         this.avatarId = settings.avatarId;
-        
+
         this.position = {x:0, y:0, z:0};
         this.rotation = {x:0, y:0, z:0, w:0};
-        
+
         this.update = function() {
             if (self.avatarId !== undefined){
                 var avatar = AvatarList.getAvatar(self.avatarId);
                 self.position = avatar.getJointPosition(self.jointIndex);
                 self.rotation = avatar.getJointRotation(self.jointIndex);
-            }               
+            }
             collisionDebug.setDebugCube(self.name, self.position, self.rotation, self.dimensions, {red: 200, green: 10, blue: 50});
         };
-        
+
         this.checkCollision = function(point, radius) {
             var localPoint = MyAvatar.worldToJointPoint(point, self.jointIndex);
             var localPosition = MyAvatar.worldToJointPoint(self.position, self.jointIndex);
             var centerToJoint = VEC3.subtract(localPoint, localPosition);
-            var offsets = { x: (self.dimensions.x/2) - Math.abs(centerToJoint.x), 
-                            y: (self.dimensions.y/2) - Math.abs(centerToJoint.y), 
+            var offsets = { x: (self.dimensions.x/2) - Math.abs(centerToJoint.x),
+                            y: (self.dimensions.y/2) - Math.abs(centerToJoint.y),
                             z: (self.dimensions.z/2) - Math.abs(centerToJoint.z)};
-                            
+
             radius = 0;
             var normal = {x: 0, y: 0, z: 0};
             var position = {x: 0, y: 0, z: 0};
             var offset = 0;
             if (offsets.x > 0 && offsets.y > 0 && offsets.z > 0) {
-                var offsetOrder = [{"coordinate": "x", "value": offsets.x}, {"coordinate": "y", "value": offsets.y}, {"coordinate": "z", "value": offsets.z}]; 
+                var offsetOrder = [{"coordinate": "x", "value": offsets.x}, {"coordinate": "y", "value": offsets.y}, {"coordinate": "z", "value": offsets.z}];
                 offsetOrder.sort(function(a, b){
                     return a.value - b.value;
                 });
@@ -779,46 +780,46 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                         normal = {x: centerToJoint.x > 0 ? 1 : -1, y: 0, z: 0};
                         radius = self.dimensions.x/2;
                         position = VEC3.sum(self.offset, {x: 0, y: centerToJoint.y, z: centerToJoint.z});
-                        offset = offsets.x;                     
+                        offset = offsets.x;
                     break;
                     case "y" :
                         normal = {x: 0, y: centerToJoint.y > 0 ? 1 : -1, z: 0};
                         radius = self.dimensions.y/2;
                         position = VEC3.sum(self.offset, {x: centerToJoint.x, y: 0, z: centerToJoint.z});
-                        offset = offsets.y; 
+                        offset = offsets.y;
                     break;
                     case "z" :
                         normal = {x: 0, y: 0, z: centerToJoint.z > 0 ? 1 : -1};
                         radius = self.dimensions.z/2;
                         position = VEC3.sum(self.offset, {x: centerToJoint.x, y: centerToJoint.y, z: 0});
-                        offset = offsets.z; 
+                        offset = offsets.z;
                     break;
                 }
                 normal = MyAvatar.jointToWorldDirection(normal, self.jointIndex);
                 position = MyAvatar.jointToWorldPoint(position, self.jointIndex);
-            }           
+            }
             return new FlowCollisionData(offset, position, radius, normal, offset);
         };
     };
-    
+
     var FlowNode = function(initialPosition, settings) {
         var self = this;
-        
+
         this.active = settings.active;
-        
+
         this.radius = this.initialRadius = settings.radius;
         this.gravity = settings.gravity;
         this.damping = settings.damping;
         this.inertia = settings.inertia;
         this.delta = settings.delta;
-        
+
         this.initialPosition = initialPosition;
-        
+
         this.previousPosition = this.initialPosition;
         this.currentPosition = this.initialPosition;
-        
+
         this.previousCollision = new FlowCollisionData();
-        
+
         this.currentVelocity = {x:0, y:0, z:0};
         this.previousVelocity = {x:0, y:0, z:0};
         this.acceleration = {x:0, y:0, z:0};
@@ -826,43 +827,42 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.anchored = false;
         this.colliding = false;
         this.collision = undefined;
-        
+
         this.update = function(accelerationOffset) {
             self.acceleration = {x: 0, y: self.gravity, z: 0};
             self.previousVelocity = self.currentVelocity;
             self.currentVelocity = VEC3.subtract(self.currentPosition, self.previousPosition);
             self.previousPosition = self.currentPosition;
-            if (!self.anchored) {   
+            if (!self.anchored) {
                 // Add inertia
                 var centrifugeVector = VEC3.normalize(VEC3.subtract(self.previousVelocity, self.currentVelocity));
                 self.acceleration = VEC3.sum(self.acceleration, VEC3.multiply(centrifugeVector, self.inertia * VEC3.length(self.currentVelocity)));
-                
+
                 // Add offset
                 self.acceleration = VEC3.sum(self.acceleration, accelerationOffset);
-                
                 // Calculate new position
                 self.currentPosition = VEC3.sum(
-                    VEC3.sum(self.currentPosition, VEC3.multiply(self.currentVelocity, self.damping)), 
-                    VEC3.multiply(self.acceleration, Math.pow(self.delta, 2))
-                );                
+                    VEC3.sum(self.currentPosition, VEC3.multiply(self.currentVelocity, self.damping)),
+                    VEC3.multiply(self.acceleration, Math.pow((self.delta * avatarScale), 2))
+                );
             } else {
                 self.acceleration = {x:0, y:0, z:0};
                 self.currentVelocity = {x:0, y:0, z:0};
             }
         };
-        
-        
+
+
         this.solve = function(constrainPoint, maxDistance, collision) {
             self.solveConstraints(constrainPoint, maxDistance);
-            self.solveCollisions(collision);      
+            self.solveCollisions(collision);
         };
-        
+
         this.solveConstraints = function(constrainPoint, maxDistance) {
             var constrainVector = VEC3.subtract(self.currentPosition, constrainPoint);
             var difference = maxDistance/VEC3.length(constrainVector);
             self.currentPosition = difference < 1.0 ? VEC3.sum(constrainPoint, VEC3.multiply(constrainVector, difference)) : self.currentPosition;
         };
-        
+
         this.solveCollisions = function(collision) {
             self.colliding = collision && (collision.offset > 0);
             self.collision = collision;
@@ -871,46 +871,47 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 self.previousCollision = collision;
             } else {
                 self.previousCollision = undefined;
-            } 
+            }
         };
-        
+
         this.apply = function(name, forceRendering) {
-            jointDebug.setDebugSphere(name, self.currentPosition, 2*self.radius, {  red: self.collision && self.collision.collisionCount > 1 ? 0 : 255, 
-                                                                                    green:self.colliding ? 0 : 255, 
+            jointDebug.setDebugSphere(name, self.currentPosition, 2*self.radius, {  red: self.collision && self.collision.collisionCount > 1 ? 0 : 255,
+                                                                                    green:self.colliding ? 0 : 255,
                                                                                     blue:0 }, forceRendering);
         };
     };
-    
+
 
     var FlowJoint = function(index, parentIndex, name, group, settings){
         var self = this;
-        
+
         this.index = index;
         this.name = name;
         this.group = group;
         this.parentIndex = parentIndex;
         this.childIndex = -1;
-        
+
         this.isDummy = false;
-        
+
         this.initialPosition = MyAvatar.getJointPosition(index);
         this.initialXform = new Xform(MyAvatar.getJointRotation(index), MyAvatar.getJointTranslation(index));
-        
+
         this.currentRotation = undefined;
         this.recoveryPosition = undefined;
-        
+
         this.node = new FlowNode(self.initialPosition, settings);
-        
+
         this.stiffness = settings.stiffness;
 
         this.translationDirection = VEC3.normalize(this.initialXform.pos);
-        
+
         this.length = VEC3.length(VEC3.subtract(this.initialPosition, MyAvatar.getJointPosition(self.parentIndex)));
-        
+        this.originalLength = this.length / avatarScale;
+
         this.update = function () {
             var accelerationOffset = {x: 0, y: 0, z: 0};
             if (self.recoveryPosition) {
-                var recoveryVector = VEC3.subtract(self.recoveryPosition, self.node.currentPosition);   
+                var recoveryVector = VEC3.subtract(self.recoveryPosition, self.node.currentPosition);
                 accelerationOffset = VEC3.multiply(recoveryVector, Math.pow(self.stiffness, 3));
             }
             self.node.update(accelerationOffset);
@@ -922,21 +923,21 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
         };
-                
+
         this.solve = function(collision) {
             var parentPosition = flowJointData[self.parentIndex] ? flowJointData[self.parentIndex].node.currentPosition : MyAvatar.getJointPosition(self.parentIndex);
-            self.node.solve(parentPosition, self.length, collision);            
+            self.node.solve(parentPosition, self.length, collision);
         };
-        
+
         this.apply = function() {
-            
+
             if (self.currentRotation) {
                 MyAvatar.setJointRotation(self.index, self.currentRotation);
             }
             self.node.apply(self.name, self.isDummy);
         };
     };
-    
+
     var FlowJointDummy = function(initialPosition, index, parentIndex, childIndex, settings) {
         var group = DUMMY_KEYWORD;
         var name = DUMMY_KEYWORD + "_" + index;
@@ -946,15 +947,23 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         this.initialPosition = initialPosition;
         this.node = new FlowNode(initialPosition, settings);
         this.length = DUMMY_JOINT_DISTANCE;
-    };   
-    
+    };
+
     var FlowThread = function(root) {
         var self = this;
         this.joints = [];
         this.positions = [];
-        this.radius = 0;
-        this.length = 0;
-        
+        this.radius = 0.0;
+        this.length = 0.0;
+
+        this.resetLength = function() {
+            self.length = 0.0;
+            for (i = 1; i < self.joints.length; i++) {
+                var index = self.joints[i];
+                self.length += flowJointData[index].length;
+            }
+        }
+
         this.computeThread = function(rootIndex) {
             var parentIndex = rootIndex;
             var childIndex = flowJointData[parentIndex].childIndex;
@@ -975,7 +984,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
         };
-        
+
         this.computeRecovery = function() {
             var parentIndex = self.joints[0];
             var parentJoint = flowJointData[parentIndex];
@@ -987,7 +996,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 joint.recoveryPosition = VEC3.sum(parentJoint.recoveryPosition, VEC3.multiplyQbyV(rotation, VEC3.multiply(joint.initialXform.pos, 0.01)));
                 parentJoint = joint;
             }
-            
+
         };
 
         this.update = function() {
@@ -1003,7 +1012,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 self.positions.push(joint.node.currentPosition);
             }
         };
-        
+
         this.solve = function(useCollisions) {
             if (!self.getActive()) {
                 return;
@@ -1020,7 +1029,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                     } else {
                         handTouchedJoint = (handCollisions[i].offset > 0) ? i : -1;
                         flowJointData[index].solve(handCollisions[i]);
-                    }                   
+                    }
                 }
             } else {
                 for (i = 0; i < self.joints.length; i++) {
@@ -1029,7 +1038,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
         };
-        
+
         this.computeJointRotations = function() {
             var rootIndex = flowJointData[self.joints[0]].parentIndex;
             var rootFramePositions = [];
@@ -1038,36 +1047,36 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             }
             var pos0 = rootFramePositions[0];
             var pos1 = rootFramePositions[1];
-            
+
             var joint0 = flowJointData[self.joints[0]];
             var joint1 = flowJointData[self.joints[1]];
-            
+
             var initial_pos1 = VEC3.sum(pos0, VEC3.multiplyQbyV(joint0.initialXform.rot, VEC3.multiply(joint1.initialXform.pos, 0.01)));
-            
+
             var vec0 = VEC3.subtract(initial_pos1, pos0);
             var vec1 = VEC3.subtract(pos1, pos0);
-            
+
             var delta = QUAT.rotationBetween(vec0, vec1);
-            
+
             joint0.currentRotation = QUAT.multiply(delta, joint0.initialXform.rot);
-            
+
             for (i = 1; i < self.joints.length-1; i++){
                 var nextJoint = flowJointData[self.joints[i+1]];
                 for (var j = i; j < self.joints.length; j++){
                     rootFramePositions[j] = VEC3.multiplyQbyV(
-                        QUAT.inverse(joint0.currentRotation), 
+                        QUAT.inverse(joint0.currentRotation),
                         VEC3.subtract(rootFramePositions[j], VEC3.multiply(joint0.initialXform.pos, 0.01))
                     );
                 }
                 pos0 = rootFramePositions[i];
                 pos1 = rootFramePositions[i+1];
                 initial_pos1 = VEC3.sum(pos0, VEC3.multiplyQbyV(joint1.initialXform.rot, VEC3.multiply(nextJoint.initialXform.pos, 0.01)));
-                
+
                 vec0 = VEC3.subtract(initial_pos1, pos0);
                 vec1 = VEC3.subtract(pos1, pos0);
-            
+
                 delta = QUAT.rotationBetween(vec0, vec1);
-            
+
                 joint1.currentRotation = QUAT.multiply(delta, joint1.initialXform.rot);
                 joint0 = joint1;
                 joint1 = nextJoint;
@@ -1084,29 +1093,29 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 var joint = flowJointData[self.joints[i]];
                 var parentJoint = flowJointData[joint.parentIndex];
                 jointDebug.setDebugLine(
-                    joint.name, 
-                    joint.node.currentPosition, 
-                    !parentJoint ? MyAvatar.getJointPosition(joint.parentIndex) : parentJoint.node.currentPosition, 
+                    joint.name,
+                    joint.node.currentPosition,
+                    !parentJoint ? MyAvatar.getJointPosition(joint.parentIndex) : parentJoint.node.currentPosition,
                     {
-                        red: 255, 
-                        green:(joint.colliding ? 0 : 255), 
+                        red: 255,
+                        green:(joint.colliding ? 0 : 255),
                         blue:0
-                    }, 
+                    },
                     joint.isDummy
                 );
                 joint.apply();
             }
         };
-        
+
         this.getActive = function() {
             return flowJointData[self.joints[0]].node.active;
         };
-        
+
         self.computeThread(root);
     };
-    
+
     var isActive, flowSkeleton, flowJointData, flowThreads, handSystem, collisionSystem, collisionDebug, jointDebug;
-    
+
     function initFlow() {
         stopFlow();
         flowSkeleton = undefined;
@@ -1115,21 +1124,21 @@ Script.include(Script.resolvePath("./VectorMath.js"));
 
         handSystem = new FlowHandSystem();
         collisionSystem = new FlowCollisionSystem();
-        
+
         collisionDebug = new FlowDebug();
         jointDebug = new FlowDebug();
-        
+
         collisionDebug.setVisible(SHOW_DEBUG_SHAPES);
         collisionDebug.setSolid(SHOW_SOLID_SHAPES);
-        
+
         MyAvatar.setEnableMeshVisible(SHOW_AVATAR);
         jointDebug.setVisible(SHOW_DEBUG_SHAPES);
         jointDebug.setSolid(SHOW_SOLID_SHAPES);
-        
+
         calculateConstraints();
         isActive = true;
     }
-    
+
     function stopFlow() {
         isActive = false;
         if (!flowSkeleton) {
@@ -1145,15 +1154,18 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         Script.requestGarbageCollection();
         MyAvatar.clearJointsData();
     }
-        
+
     var setFlowScale = function(scale) {
         collisionSystem.setScale(scale);
         handSystem.setScale(scale);
         for (var i = 0; i < flowThreads.length; i++) {
             for (var j = 0; j < flowThreads[i].joints.length; j++){
                 var joint = flowJointData[flowThreads[i].joints[j]];
-                joint.node.radius = joint.node.initialRadius * scale;
+                var deltaScale =  joint.node.initialRadius * scale / joint.node.radius;
+                joint.node.radius *= deltaScale;
+                joint.length = joint.originalLength * scale;
             }
+            flowThreads[i].resetLength();
         }
     };
 
@@ -1170,6 +1182,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 if (isFlowJoint || isSimJoint) {
                     var group = undefined;
                     if (isSimJoint) {
+                    console.log("FLOW is sim: " + name);
                         for (var k = 1; k < name.length-1; k++) {
                             var subname = parseFloat(name.substring(name.length-k));
                             if (isNaN(subname) && name.length-k > SIM_JOINT_PREFIX.length) {
@@ -1209,9 +1222,9 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 return (isFlowJoint || isSimJoint);
             }
         );
-        
+
         var roots = [];
-        
+
         for (var i = 0; i < flowSkeleton.length; i++) {
             var index = flowSkeleton[i].index;
             var flowJoint = flowJointData[index];
@@ -1221,9 +1234,9 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             } else {
                 flowJoint.node.anchored = true;
                 roots.push(index);
-            }      
+            }
         }
-        
+
         for (i = 0; i < roots.length; i++) {
             var thread = new FlowThread(roots[i]);
             // add threads with at least 2 joints
@@ -1255,7 +1268,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         if (flowThreads.length === 0) {
             MyAvatar.clearJointsData();
         }
-        
+
         if (SHOW_DUMMY_JOINTS) {
             var jointCount = flowJointData.length;
             var extraIndex = flowJointData.length;
@@ -1269,26 +1282,26 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 extraIndex++;
             }
             flowJointData[jointCount].node.anchored = true;
-        
+
             var extraThread = new FlowThread(jointCount);
             flowThreads.push(extraThread);
         }
-        setFlowScale(MyAvatar.scale);
+        setFlowScale(avatarScale);
     };
-    
+
 
     Script.update.connect(function(){
         if (!isActive || !flowSkeleton) return;
-        
+
         if (USE_COLLISIONS) {
             Script.beginProfileRange("JS-Update-Collisions");
             collisionSystem.update();
             handSystem.update();
             Script.endProfileRange("JS-Update-Collisions");
         }
-        
+
         Script.beginProfileRange("JS-Update-JointsUpdate");
-        
+
         flowThreads.forEach(function(thread){
             thread.update();
         });
@@ -1299,19 +1312,19 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         flowThreads.forEach(function(thread){
             thread.solve(USE_COLLISIONS);
         });
-        
+
         Script.endProfileRange("JS-Update-JointsSolve");
         Script.beginProfileRange("JS-Update-JointsApply");
-        
+
         flowThreads.forEach(function(thread){
             thread.apply();
         });
 
         Script.endProfileRange("JS-Update-JointsApply");
     });
-    
+
     Script.scriptEnding.connect(stopFlow);
-    
+
     MyAvatar.skeletonChanged.connect(function(){
         Script.setTimeout(function() {
             stopFlow();
@@ -1319,17 +1332,18 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             initFlow();
         }, 200);
     });
-    
+
     MyAvatar.scaleChanged.connect(function(){
+        avatarScale = MyAvatar.scale;
         if (isActive) {
-            setFlowScale(MyAvatar.scale);
+            setFlowScale(avatarScale);
         }
     });
-    
+
     var varsToDebug = {
         "init": function() {
             initFlow();
-        },      
+        },
         "stop": function() {
             stopFlow();
         },
@@ -1378,8 +1392,8 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                             joint.stiffness = floatVal;
                         } else if (name === "radius") {
                             joint.node.initialRadius = floatVal;
-                            joint.node.radius = MyAvatar.scale*floatVal;
-                        } 
+                            joint.node.radius = avatarScale*floatVal;
+                        }
                         else {
                             joint.node[name] = floatVal;
                         }
@@ -1391,7 +1405,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             var jointName = group;
             var floatVal = parseFloat(value);
             collisionSystem.modifyCollision(jointName, name, floatVal);
-        }, 
+        },
         "getGroupData": function() {
             var joint_filter_keys = FLOW_JOINT_DATA;
             if (isActive) {
@@ -1406,11 +1420,11 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                         if (!joint_filter_keys[joint.group]) {
                             joint_filter_keys[joint.group] = {
                                 "active": joint.node.active,
-                                "stiffness": joint.stiffness, 
+                                "stiffness": joint.stiffness,
                                 "radius": joint.node.initialRadius,
                                 "gravity": joint.node.gravity,
-                                "damping": joint.node.damping, 
-                                "inertia": joint.node.inertia, 
+                                "damping": joint.node.damping,
+                                "inertia": joint.node.inertia,
                                 "delta": joint.node.delta
                             };
                         }
@@ -1418,7 +1432,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
                 }
             }
             return joint_filter_keys;
-            
+
         },
         "getDisplayData": function() {
             return {"avatar": SHOW_AVATAR, "collisions": USE_COLLISIONS, "debug": SHOW_DEBUG_SHAPES, "solid": SHOW_SOLID_SHAPES};
@@ -1436,12 +1450,12 @@ Script.include(Script.resolvePath("./VectorMath.js"));
             collisionSystem.removeCollisionFromJoint(jointName);
         }
     };
-        
+
     // Register GlobalDebugger for API Debugger
     Script.registerValue("GlobalDebugger", varsToDebug);
 
     // Capture the controller values
-    
+
     var leftTriggerPress = function (val) {
         var value = (val <= 1) ? val : 0;
         handSystem.setLeftTriggerValue(value);
@@ -1451,7 +1465,7 @@ Script.include(Script.resolvePath("./VectorMath.js"));
         var value = (val <= 1) ? val : 0;
         handSystem.setRightTriggerValue(value);
     };
-    
+
     var MAPPING_NAME = "com.highfidelity.hairTouch";
     var mapping = Controller.newMapping(MAPPING_NAME);
     mapping.from([Controller.Standard.RT]).peek().to(rightTriggerPress);


### PR DESCRIPTION
This PR fix a scaling bug on flow.js. 

https://highfidelity.manuscript.com/f/cases/20492/flow-js-needs-to-detect-and-reset-after-avatar-scale-change-or-flow-bones-act-funny

Now the length of threads are also scaled. It also add some scaling to the delta parameter to avoid big changes on physics behavior when adopting extreme scale values.