### PR TITLE
Appreciate: Introduce functionality to stop running baked versions

### DIFF
--- a/marketplaceItems/appreciate/README.md
+++ b/marketplaceItems/appreciate/README.md
@@ -6,11 +6,15 @@ Show someone else that you like what they're doing. Open the app to see usage in
 
 ## Releases
 
-2019-02-15_17-03-00 :: [83f8927](https://github.com/highfidelity/hifi-content/commit/83f8927)
+### 2019-02-19_13-09-00 | Marketplace v1.2 | [0e2fa82](https://github.com/highfidelity/hifi-content/commit/0e2fa82)
+
+- Introduced functionality to stop running versions of Appreciate when those versions are baked into the client installation AND other versions of Appreciate are running
+
+### 2019-02-15_17-03-00 | Marketplace v1.1 | [83f8927](https://github.com/highfidelity/hifi-content/commit/83f8927)
 
 - Ensure that old Appreciation Dodecahedrons will be deleted in the event of a client crashing while Appreciating
 
-2019-02-14_10-00-00 :: [appreciation 658ed4e6b7a834d64baed451601ab52e8ef3150d](https://github.com/highfidelity/hifi-content/commit/658ed4e6b7a834d64baed451601ab52e8ef3150d)
+### 2019-02-14_10-00-00 | Marketplace v1.0 | [658ed4e](https://github.com/highfidelity/hifi-content/commit/658ed4e)
 
 - Initial Release
 

--- a/marketplaceItems/appreciate/appResources/appData/appreciate_app.js
+++ b/marketplaceItems/appreciate/appResources/appData/appreciate_app.js
@@ -981,6 +981,34 @@
     }
 
 
+    // When called, this function will stop the versions of this script that are
+    // baked into the client installation IF there's another version of the script
+    // running that ISN'T the baked version.
+    function maybeStopBakedScriptVersions() {
+        var THIS_SCRIPT_FILENAME = "appreciate_app.js";
+        var RELATIVE_PATH_TO_BAKED_SCRIPT = "system/experiences/appreciate/appResources/appData/" + THIS_SCRIPT_FILENAME;
+        var bakedLocalScriptPaths = [];
+        var alsoRunningNonBakedVersion = false;
+
+        var runningScripts = ScriptDiscoveryService.getRunning();
+        runningScripts.forEach(function(scriptObject) {
+            if (scriptObject.local && scriptObject.url.indexOf(RELATIVE_PATH_TO_BAKED_SCRIPT) > -1) {
+                bakedLocalScriptPaths.push(scriptObject.path);
+            }
+
+            if (scriptObject.name === THIS_SCRIPT_FILENAME && scriptObject.url.indexOf(RELATIVE_PATH_TO_BAKED_SCRIPT) === -1) {
+                alsoRunningNonBakedVersion = true;
+            }
+        });
+
+        if (alsoRunningNonBakedVersion && bakedLocalScriptPaths.length > 0) {
+            for (var i = 0; i < bakedLocalScriptPaths.length; i++) {
+                ScriptDiscoveryService.stopScript(bakedLocalScriptPaths[i]);
+            }
+        }
+    }
+
+
     // Called when the script starts up
     var BUTTON_NAME = "APPRECIATE";
     var APP_UI_URL = Script.resolvePath('resources/appreciate_ui.html');
@@ -1004,6 +1032,7 @@
         getSounds();
         getAnimations();
         HMD.displayModeChanged.connect(enableOrDisableAppreciate);
+        maybeStopBakedScriptVersions();
     }
 
 

--- a/marketplaceItems/appreciate/marketplaceResources/description.md
+++ b/marketplaceItems/appreciate/marketplaceResources/description.md
@@ -4,6 +4,10 @@ Open the app to view usage instructions and some app options, including an optio
 
 **Changelog:**
 
+v1.2 (2019-02)
+
+- Introduced functionality to stop running versions of Appreciate when those versions are baked into the client installation AND other versions of Appreciate are running
+
 v1.1 (2019-02)
 
 - Ensure that old Appreciation Dodecahedrons will be deleted in the event of a client crashing while Appreciating


### PR DESCRIPTION
QA testing is a bit involved for this one.

First, ensure the Appreciate App isn't already running. Then:

1. Open your file explorer to the place you have Interface installed
    1. For example, for Steam, that might be `C:\Program Files (x86)\Steam\steamapps\common\High Fidelity`
2. Open the `scripts` folder, then open the `system` folder.
3. Create a new folder in there called `experiences` (if that folder doesn't already exist).
4. Copy the `appreciate` folder from this source tree into that new `experiences` folder.
5. Navigate into the `appreciate/appResources/appData/` folder.
6. From that folder, drag `appreciate_app.js` into the Interface window, then say "Yes" when asked if you want to run the script.
7. Run a quick smoke test on Appreciate to make sure it works.
8. Without manually killing the Appreciate app, run the released version of Appreciate from this URL: `https://hifi-content.s3.amazonaws.com/Experiences/Releases/marketPlaceItems/appreciate/2019-02-19_13-09-00/appResources/appData/appreciate_app.js`
9. In the Running Scripts window, verify that the version of `appreciate_app.js` that you ran from your local disk is now **no longer running**.
10. Run a quick smoke test of the version of Appreciate that is running from S3.