### PR TITLE
Scale avatar

### DIFF
--- a/usefulUtilities/scaleAvatar/README.md
+++ b/usefulUtilities/scaleAvatar/README.md
@@ -10,5 +10,5 @@ In VR, when you hold down both grips and both triggers, your avatar can scale it
 
 # Release Notes
 ## Version 2019-03-11_11_50_00
-commit 38a75210f31c46b4b23b285859d2f33159fce163
+commit 7534c2a
 - Initial release

--- a/usefulUtilities/scaleAvatar/README.md
+++ b/usefulUtilities/scaleAvatar/README.md
@@ -9,6 +9,6 @@ In VR, when you hold down both grips and both triggers, your avatar can scale it
 - Moving hands together will scale your avatar smaller
 
 # Release Notes
-## Version 2019-03-11_11_50_00
-commit 7534c2a
+## Version 2019-03-04_58_00
+commit 08b5c68
 - Initial release

--- a/usefulUtilities/scaleAvatar/README.md
+++ b/usefulUtilities/scaleAvatar/README.md
@@ -1,0 +1,14 @@
+# Scale Avatar
+
+Use the hand controllers to scale your avatar.
+
+Run scaleAvatar.js script in High Fidelity client via "Edit" > "Running Scripts...".
+
+In VR, when you hold down both grips and both triggers, your avatar can scale itself: 
+- Moving hands away from eachother will scale your avatar larger 
+- Moving hands together will scale your avatar smaller
+
+# Release Notes
+## Version 2019-03-11_11_50_00
+commit 38a75210f31c46b4b23b285859d2f33159fce163
+- Initial release

--- a/usefulUtilities/scaleAvatar/scaleAvatar.js
+++ b/usefulUtilities/scaleAvatar/scaleAvatar.js
@@ -1,9 +1,18 @@
-/*
-
-*/
-
+//
+//  scaleAvatar.js
+//
+//  Run script on client. In VR, when you hold down both grips and both triggers, 
+//  scale your avatar your avatar by moving your hands further away from eachother 
+//  to scale larger or closer together to scale smaller.
+//
+//  Created by Robin Wilson on 3/11/2019
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
 (function () {
-    var DEBUG = true;
+    var DEBUG = false;
 
     // Returns boolean that all buttons are pressed
     var isPressed = {

--- a/usefulUtilities/scaleAvatar/scaleAvatar.js
+++ b/usefulUtilities/scaleAvatar/scaleAvatar.js
@@ -1,10 +1,35 @@
 (function () {
-    var CONTROLLER_MAPPING_LEFT = "com.highfidelity.scaleAvatarLeft",
-        CONTROLLER_MAPPING_RIGHT = "com.highfidelity.scaleAvatarRight";
+    var CONTROLLER_MAPPING_GRIP_LEFT = "com.highfidelity.scaleAvatarGripLeft",
+        CONTROLLER_MAPPING_GRIP_RIGHT = "com.highfidelity.scaleAvatarGripRight";
+    var CONTROLLER_MAPPING_TRIGGER_LEFT = "com.highfidelity.scaleAvatarTriggerLeft",
+        CONTROLLER_MAPPING_TRIGGER_RIGHT = "com.highfidelity.scaleAvatarTriggerRight";
 
     var isRightPressed = false;
     var isLeftPressed = false;
     var PRESSED_MIN_VALUE = 0.8;
+
+    var GRABBING_ENTITY_CHANNEL = 'Hifi-Object-Manipulation';
+    
+    Messages.subscribe('Hifi-Object-Manipulation');
+    Messages.messageReceived.connect(onMessageRecieved);
+
+    var STRING_GRAB = "grab";
+    var STRING_RELEASE = "release";
+    var stopScale = false;
+    function onMessageRecieved(messageName, infoString) { 
+        if (messageName === GRABBING_ENTITY_CHANNEL) {
+            if (infoString.indexOf(STRING_GRAB)) {
+
+                // GRABBING A THING
+            }
+        }
+    }
+
+    // Messages.sendMessage('Hifi-Object-Manipulation', JSON.stringify({
+    //     action: 'grab',
+    //     grabbedEntity: targetProps.id,
+    //     joint: this.hand === RIGHT_HAND ? "RightHand" : "LeftHand"
+    // }));
 
     var DEBUG = true;
 
@@ -110,6 +135,10 @@
         }
     }
 
+    function isGrabbingEntity() {
+
+    }
+
 
     // Get the distance between the avatar's hands
     function distanceBetweenHands() {
@@ -120,19 +149,19 @@
 
 
     function setupScaleAvatarWithGrip() {
-        var controllerMapping = Controller.newMapping(CONTROLLER_MAPPING_LEFT);
+        var controllerMapping = Controller.newMapping(CONTROLLER_MAPPING_GRIP_LEFT);
         controllerMapping.from(Controller.Standard.LeftGrip).to(leftOnGripPress);
-        Controller.enableMapping(CONTROLLER_MAPPING_LEFT);
+        Controller.enableMapping(CONTROLLER_MAPPING_GRIP_LEFT);
 
-        controllerMapping = Controller.newMapping(CONTROLLER_MAPPING_RIGHT);
+        controllerMapping = Controller.newMapping(CONTROLLER_MAPPING_GRIP_RIGHT);
         controllerMapping.from(Controller.Standard.RightGrip).to(rightOnGripPress);
-        Controller.enableMapping(CONTROLLER_MAPPING_RIGHT);
+        Controller.enableMapping(CONTROLLER_MAPPING_GRIP_RIGHT);
     }
 
 
     function unload() {
-        Controller.disableMapping(CONTROLLER_MAPPING_LEFT);
-        Controller.disableMapping(CONTROLLER_MAPPING_RIGHT);
+        Controller.disableMapping(CONTROLLER_MAPPING_GRIP_LEFT);
+        Controller.disableMapping(CONTROLLER_MAPPING_GRIP_RIGHT);
 
         if (pressedInterval) {
             Script.clearInterval(pressedInterval);

--- a/usefulUtilities/scaleAvatar/scaleAvatar.js
+++ b/usefulUtilities/scaleAvatar/scaleAvatar.js
@@ -1,0 +1,142 @@
+(function () {
+    var CONTROLLER_MAPPING_LEFT = "com.highfidelity.scaleAvatarLeft",
+        CONTROLLER_MAPPING_RIGHT = "com.highfidelity.scaleAvatarRight";
+
+    var isRightPressed = false;
+    var isLeftPressed = false;
+    var PRESSED_MIN_VALUE = 0.8;
+
+    var DEBUG = true;
+
+    function rightOnGripPress(value) {
+        if (!isRightPressed && value >= PRESSED_MIN_VALUE) { // not already pressed and value > 0.8
+            
+            if (isNearGrabbingObject(STRING_RIGHT)) {
+                return;
+            }
+            
+            isRightPressed = true;
+            if (DEBUG) {
+                print("right pressed!");
+            }
+        } else if (isRightPressed && value < PRESSED_MIN_VALUE) {
+            isRightPressed = false;
+        }
+        handleBothGripPressed();
+    }
+
+    var STRING_LEFT = "left";
+    var STRING_RIGHT = "right";
+    function isNearGrabbingObject(handString) {
+
+        var controller = handString === STRING_LEFT ? Controller.Standard.LeftHand : Controller.Standard.RightHand;
+        var handPosition = Controller.getPoseValue(controller).translation / MyAvatar.sensorToWorldScale;
+        var entityList = Entities.findEntities(handPosition, NEAR_GRAB_RADIUS_M);
+
+        for (var i = 0; i < entityList.length; i++) {
+            var parentID = Entities.getEntityProperties(entityList[i], "parentID").parentID;
+            if (MyAvatar.sessionUUID === parentID) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    var NEAR_GRAB_RADIUS_M = 1.0;
+    function leftOnGripPress(value) {
+        if (!isLeftPressed && value >= PRESSED_MIN_VALUE) { // not already pressed and value > 0.8
+            
+            if (isNearGrabbingObject(STRING_LEFT)) {
+                return;
+            }
+
+            isLeftPressed = true;
+            if (DEBUG) {
+                print("left pressed!");
+            }
+        } else if (isLeftPressed && value < PRESSED_MIN_VALUE) {
+            isLeftPressed = false;
+        }
+        handleBothGripPressed();
+    }
+
+
+    var SCALE_BUFFER = 1; // increase/decrease the sensitivity of scaling
+    var PRESSED_INTERVAL_MS = 25; 
+    var isPressed = false; // both grips pressed
+    var initialDistance = null;
+    var initialScale = null;
+    var pressedInterval = null;
+    function handleBothGripPressed() {
+        if (isRightPressed && isLeftPressed && isPressed) {
+            // setup done, do not need to continue
+            // or either left or right is not pressed
+            return;
+        }
+
+        if (isRightPressed && isLeftPressed) {
+            if (!isPressed) {
+                // Both pressed initially
+                initialDistance = distanceBetweenHands();
+                isPressed = true;
+                initialScale = MyAvatar.scale;
+
+                // Setup pressed interval
+                pressedInterval = Script.setInterval(function() {
+                    if (isPressed) {
+                        if (DEBUG) {
+                            print("init" + JSON.stringify(initialDistance));
+                            print("distance" + JSON.stringify(distanceBetweenHands()));
+                        }
+                        var currentDistance = distanceBetweenHands();
+                        var deltaDistance = currentDistance - initialDistance;
+                        MyAvatar.scale = initialScale + deltaDistance * SCALE_BUFFER;
+                    }
+                }, PRESSED_INTERVAL_MS);
+            }
+        } else {
+            // remove pressed interval
+            if (pressedInterval) {
+                if (DEBUG) {
+                    print("CLEAR INTERVAL");
+                }
+                Script.clearInterval(pressedInterval);
+                pressedInterval = null;
+                isPressed = false;
+                initialDistance = null;
+            }
+        }
+    }
+
+
+    // Get the distance between the avatar's hands
+    function distanceBetweenHands() {
+        var rightHand = Controller.getPoseValue(Controller.Standard.RightHand).translation;
+        var leftHand = Controller.getPoseValue(Controller.Standard.LeftHand).translation;
+        return Vec3.distance(rightHand, leftHand) / MyAvatar.sensorToWorldScale;
+    }
+
+
+    function setupScaleAvatarWithGrip() {
+        var controllerMapping = Controller.newMapping(CONTROLLER_MAPPING_LEFT);
+        controllerMapping.from(Controller.Standard.LeftGrip).to(leftOnGripPress);
+        Controller.enableMapping(CONTROLLER_MAPPING_LEFT);
+
+        controllerMapping = Controller.newMapping(CONTROLLER_MAPPING_RIGHT);
+        controllerMapping.from(Controller.Standard.RightGrip).to(rightOnGripPress);
+        Controller.enableMapping(CONTROLLER_MAPPING_RIGHT);
+    }
+
+
+    function unload() {
+        Controller.disableMapping(CONTROLLER_MAPPING_LEFT);
+        Controller.disableMapping(CONTROLLER_MAPPING_RIGHT);
+
+        if (pressedInterval) {
+            Script.clearInterval(pressedInterval);
+        }
+    }
+
+    setupScaleAvatarWithGrip();
+    Script.scriptEnding.connect(unload);
+})();

--- a/usefulUtilities/scaleAvatar/scaleAvatar.js
+++ b/usefulUtilities/scaleAvatar/scaleAvatar.js
@@ -1,12 +1,8 @@
 //
 //  scaleAvatar.js
 //
-//  Run script on client. In VR, when you hold down both grips and both triggers, 
-//  scale your avatar your avatar by moving your hands further away from eachother 
-//  to scale larger or closer together to scale smaller.
-//
 //  Created by Robin Wilson on 3/11/2019
-//  Copyright 2017 High Fidelity, Inc.
+//  Copyright 2019 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -27,33 +23,28 @@
 
 
     // Sets up the scaling functionality if all buttons are pressed
-    var SCALE_BUFFER = 1, // increase/decrease the sensitivity of scaling
-        PRESSED_INTERVAL_MS = 25, 
-        isScaling = false, // the avatar is scaling after triggers and grips are pressed
+    var PRESSED_INTERVAL_MS = 25, 
         initialDistance = null,
         initialScale = null,
         scalingInterval = null;
     function handleAllPressed() {
-        if (areAllPressed() && isScaling) {
+        if (areAllPressed() && scalingInterval) {
             // setup was completed already, do not need to continue
             return;
-        } else if (areAllPressed() && !isScaling) {
+        } else if (areAllPressed() && !scalingInterval) {
             // Initial time isScaling called
             initialDistance = distanceBetweenHands();
-            isScaling = true;
             initialScale = MyAvatar.scale;
 
             // Setup pressed interval
             scalingInterval = Script.setInterval(function() {
-                if (isScaling) {
-                    if (DEBUG) {
-                        print("init" + JSON.stringify(initialDistance));
-                        print("distance" + JSON.stringify(distanceBetweenHands()));
-                    }
-                    var currentDistance = distanceBetweenHands();
-                    var deltaDistance = currentDistance - initialDistance;
-                    MyAvatar.scale = initialScale + deltaDistance * SCALE_BUFFER;
+                if (DEBUG) {
+                    print("init" + JSON.stringify(initialDistance));
+                    print("distance" + JSON.stringify(distanceBetweenHands()));
                 }
+                var currentDistance = distanceBetweenHands();
+                var deltaDistance = currentDistance - initialDistance;
+                MyAvatar.scale = initialScale + deltaDistance;
             }, PRESSED_INTERVAL_MS);
         } else {
             // areAllPressed is false 
@@ -64,7 +55,6 @@
                 }
                 Script.clearInterval(scalingInterval);
                 scalingInterval = null;
-                isScaling = false;
                 initialDistance = null;
             }
         }
@@ -80,28 +70,25 @@
 
 
     // With specific controller button, sets up controller pressed callback
-    var PRESSED_MIN_VALUE = 0.8;
+    var PRESSED_MIN_VALUE = 0.95;
     function setupButtonPressListener(isPressedKey, controllerReference, mappingName) {
-        var isPressedKeyName = isPressedKey;
-        var MAPPING_NAME = mappingName;
-
         function pressedCallback(value) {
-            if (!isPressed[isPressedKeyName] && value >= PRESSED_MIN_VALUE) { 
+            if (!isPressed[isPressedKey] && value >= PRESSED_MIN_VALUE) { 
                 // not already pressed and value > 0.8
                 if (DEBUG) {
-                    print(isPressedKeyName + " pressed!");
+                    print(isPressedKey + " pressed!");
                 }
-                isPressed[isPressedKeyName] = true;
-            } else if (isPressed[isPressedKeyName] && value < PRESSED_MIN_VALUE) {
+                isPressed[isPressedKey] = true;
+            } else if (isPressed[isPressedKey] && value < PRESSED_MIN_VALUE) {
                 // stop pressing button
-                isPressed[isPressedKeyName] = false;
+                isPressed[isPressedKey] = false;
             }
             handleAllPressed();
         }
-
-        var controllerMapping = Controller.newMapping(MAPPING_NAME);
+        // Map the controller button to the presssedCallback
+        var controllerMapping = Controller.newMapping(mappingName);
         controllerMapping.from(controllerReference).to(pressedCallback);
-        Controller.enableMapping(MAPPING_NAME);
+        Controller.enableMapping(mappingName);
     }
 
 
@@ -130,6 +117,7 @@
         }
     }
 
+    
     setupScaleAvatarWithGrip();
     Script.scriptEnding.connect(unload);
 })();

--- a/usefulUtilities/scaleAvatar/scaleAvatar.js
+++ b/usefulUtilities/scaleAvatar/scaleAvatar.js
@@ -10,15 +10,15 @@
 
     function rightOnGripPress(value) {
         if (!isRightPressed && value >= PRESSED_MIN_VALUE) { // not already pressed and value > 0.8
+            if (DEBUG) {
+                print("right pressed!");
+            }
             
             if (isNearGrabbingObject(STRING_RIGHT)) {
                 return;
             }
             
             isRightPressed = true;
-            if (DEBUG) {
-                print("right pressed!");
-            }
         } else if (isRightPressed && value < PRESSED_MIN_VALUE) {
             isRightPressed = false;
         }
@@ -34,8 +34,10 @@
         var entityList = Entities.findEntities(handPosition, NEAR_GRAB_RADIUS_M);
 
         for (var i = 0; i < entityList.length; i++) {
-            var parentID = Entities.getEntityProperties(entityList[i], "parentID").parentID;
-            if (MyAvatar.sessionUUID === parentID) {
+            var properties = Entities.getEntityProperties(entityList[i], ["parentID", "grabbable"]).parentID;
+            var parentID = properties.parentID;
+            var grabbable = properties.grabbable;
+            if (grabbable && MyAvatar.sessionUUID === parentID) {
                 return true;
             }
         }
@@ -45,15 +47,15 @@
     var NEAR_GRAB_RADIUS_M = 1.0;
     function leftOnGripPress(value) {
         if (!isLeftPressed && value >= PRESSED_MIN_VALUE) { // not already pressed and value > 0.8
+            if (DEBUG) {
+                print("left pressed!");
+            }
             
             if (isNearGrabbingObject(STRING_LEFT)) {
                 return;
             }
 
             isLeftPressed = true;
-            if (DEBUG) {
-                print("left pressed!");
-            }
         } else if (isLeftPressed && value < PRESSED_MIN_VALUE) {
             isLeftPressed = false;
         }


### PR DESCRIPTION
Can scale avatar up and down when the user holds both triggers AND both grips.

Test: 

Run this script in interface:
http://hifi-content.s3-us-west-1.amazonaws.com/Experiences/Releases/usefulUtilities/scaleAvatar/2019-03-04_58_00/scaleAvatar.js

- Hold down all grips and triggers:
    - Move hands further away from eachother - SCALE UP
   - Move hands closer together from eachother - SCALE DOWN
- You will not scale unless ALL grip and triggers are held down