### PR TITLE
Appreciate App v1.5

### DIFF
--- a/marketplaceItems/appreciate/README.md
+++ b/marketplaceItems/appreciate/README.md
@@ -6,7 +6,7 @@ Show someone else that you like what they're doing. Open the app to see usage in
 
 ## Releases
 
-### v1.5 | [93bf464](https://github.com/highfidelity/hifi-content/commit/93bf464)
+### v1.5 | [48d8247](https://github.com/highfidelity/hifi-content/commit/48d8247)
 
 - Fixed an issue where Appreciate app users wearing avatars without a specific joint wouldn't hear the Appreciate sound or see the Appreciation Dodecahedron
 

--- a/marketplaceItems/appreciate/README.md
+++ b/marketplaceItems/appreciate/README.md
@@ -6,6 +6,10 @@ Show someone else that you like what they're doing. Open the app to see usage in
 
 ## Releases
 
+### v1.5 | [93bf464](https://github.com/highfidelity/hifi-content/commit/93bf464)
+
+- Fixed an issue where Appreciate app users wearing avatars without a specific joint wouldn't hear the Appreciate sound or see the Appreciation Dodecahedron
+
 ### 2019-03-08_11-37-00 | Marketplace v1.4 | [93bf464](https://github.com/highfidelity/hifi-content/commit/93bf464)
 
 - Fixed an issue where a user could press the "Z" key to appreciate while the Appreciate UI was focused even if the Appreciate switch was turned off

--- a/marketplaceItems/appreciate/appResources/appData/appreciate_app.js
+++ b/marketplaceItems/appreciate/appResources/appData/appreciate_app.js
@@ -22,9 +22,20 @@
         if (!leftHandPosition) {
             leftHandPosition = MyAvatar.getJointPosition("LeftHand");
         }
+        if (!leftHandPosition) {
+            leftHandPosition = MyAvatar.getJointPosition("LeftArm");
+        }
+
         var rightHandPosition = MyAvatar.getJointPosition("RightHandMiddle2");
         if (!rightHandPosition) {
             rightHandPosition = MyAvatar.getJointPosition("RightHand");
+        }
+        if (!rightHandPosition) {
+            rightHandPosition = MyAvatar.getJointPosition("RightArm");
+        }
+
+        if (!(leftHandPosition && rightHandPosition)) {
+            return MyAvatar.position;
         }
 
         var centerPosition = Vec3.sum(leftHandPosition, rightHandPosition);

--- a/marketplaceItems/appreciate/appResources/appData/appreciate_app.js
+++ b/marketplaceItems/appreciate/appResources/appData/appreciate_app.js
@@ -16,29 +16,33 @@
     var CM_PER_M = 100;
     var HALF = 0.5;
 
+
+    // Returns the first valid joint position from the list of supplied test joint positions.
+    // If none are valid, returns MyAvatar.position.
+    function getValidJointPosition(jointsToTest) {
+        var currentJointIndex;
+
+        for (var i = 0; i < jointsToTest.length; i++) {
+            currentJointIndex = MyAvatar.getJointIndex(jointsToTest[i]);
+
+            if (currentJointIndex > -1) {
+                return MyAvatar.getJointPosition(jointsToTest[i]);
+            }
+        }
+
+        return MyAvatar.position;
+    } 
+
+
     // Returns the world position halfway between the user's hands
-    function halfwayBetweenHands() {
-        var leftHandPosition = MyAvatar.getJointPosition("LeftHandMiddle2");
-        if (!leftHandPosition) {
-            leftHandPosition = MyAvatar.getJointPosition("LeftHand");
-        }
-        if (!leftHandPosition) {
-            leftHandPosition = MyAvatar.getJointPosition("LeftArm");
-        }
+    function getAppreciationPosition() {
+        var validLeftJoints = ["LeftHandMiddle2", "LeftHand", "LeftArm"];
+        var leftPosition = getValidJointPosition(validLeftJoints);
 
-        var rightHandPosition = MyAvatar.getJointPosition("RightHandMiddle2");
-        if (!rightHandPosition) {
-            rightHandPosition = MyAvatar.getJointPosition("RightHand");
-        }
-        if (!rightHandPosition) {
-            rightHandPosition = MyAvatar.getJointPosition("RightArm");
-        }
+        var validRightJoints = ["RightHandMiddle2", "RightHand", "RightArm"];;
+        var rightPosition = getValidJointPosition(validRightJoints);
 
-        if (!(leftHandPosition && rightHandPosition)) {
-            return MyAvatar.position;
-        }
-
-        var centerPosition = Vec3.sum(leftHandPosition, rightHandPosition);
+        var centerPosition = Vec3.sum(leftPosition, rightPosition);
         centerPosition = Vec3.multiply(centerPosition, HALF);
 
         return centerPosition;
@@ -253,7 +257,7 @@
                 var color = linearScaleColor(currentIntensity, intensityEntityColorMin, intensityEntityColorMax);
 
                 var propsToUpdate = {
-                    position: halfwayBetweenHands()
+                    position: getAppreciationPosition()
                 };
 
                 var currentDimensions = Vec3.multiply(INTENSITY_ENTITY_MAX_DIMENSIONS, currentIntensity);
@@ -278,7 +282,7 @@
                 Entities.editEntity(intensityEntity, propsToUpdate);
             } else {
                 var props = INTENSITY_ENTITY_PROPERTIES;
-                props.position = halfwayBetweenHands();
+                props.position = getAppreciationPosition();
 
                 currentInitialAngularVelocity.x =
                     randomFloat(INTENSITY_ENTITY_MIN_ANGULAR_VELOCITY.x, INTENSITY_ENTITY_MAX_ANGULAR_VELOCITY.x);
@@ -436,7 +440,7 @@
         }
 
         var injectorOptions = {
-            position: halfwayBetweenHands(),
+            position: getAppreciationPosition(),
             volume: calculateInjectorVolume()
         };
 
@@ -463,7 +467,7 @@
         }
 
         soundInjector = Audio.playSound(sound, {
-            position: halfwayBetweenHands(),
+            position: getAppreciationPosition(),
             volume: calculateInjectorVolume(),
             pitch: randomFloat(MINIMUM_PITCH, MAXIMUM_PITCH)
         });

--- a/marketplaceItems/appreciate/appResources/appData/resources/appreciate_ui.html
+++ b/marketplaceItems/appreciate/appResources/appData/resources/appreciate_ui.html
@@ -25,7 +25,7 @@
         <div id="mainContainer">
             <div id="titleBarContainer">
                 <div id="titleText" style="font-weight:bold;">
-                    Appreciate v1.4
+                    Appreciate v1.5
                 </div>
                 <label class="switch">
                     <input id="appreciateSwitch" type="checkbox" onclick="appreciateSwitchClicked(this)">

--- a/marketplaceItems/appreciate/marketplaceResources/description.md
+++ b/marketplaceItems/appreciate/marketplaceResources/description.md
@@ -4,6 +4,10 @@ Open the app to view usage instructions and some app options, including an optio
 
 **Changelog:**
 
+v1.5 (2019-04)
+
+- Fixed an issue where Appreciate app users wearing avatars without a specific joint wouldn't hear the Appreciate sound or see the Appreciation Dodecahedron
+
 v1.4 (2019-03)
 
 - Fixed an issue where a user could press the "Z" key to appreciate while the Appreciate UI was focused even if the Appreciate switch was turned off


### PR DESCRIPTION
Fixed an issue where Appreciate app users wearing avatars without a specific joint wouldn't hear the Appreciate sound or see the Appreciation Dodecahedron

To test:
1. Wear an avatar without `RightHandMiddle2` and `LeftHandMiddle2` joints and WITH `RightArm` and `LeftArm` joints
    - Verify that the Appreciation Dodecahedron and sound comes from between your two arm joints.
2. Wear an avatar without `RightHandMiddle2` and `LeftHandMiddle2` joints and ALSO without `RightArm` and `LeftArm` joints
    - Verify that the Appreciation Dodecahedron and sound comes from your avatar's position (probably at torso).