### PR TITLE
Unmute zone

### DIFF
--- a/usefulUtilities/loudApp/README.md
+++ b/usefulUtilities/loudApp/README.md
@@ -14,5 +14,5 @@ Happy loud sniping!
 
 ## Releases
 
-## 2019-04-15_13-00-00 :: [e1f15490](https://github.com/highfidelity/hifi-content/commit/e1f15490)
+## 2019-03-26_16-20-00 :: [f05c4fdb](https://github.com/highfidelity/hifi-content/commit/f05c4fdb)
 - Initial release

--- a/usefulUtilities/loudApp/README.md
+++ b/usefulUtilities/loudApp/README.md
@@ -14,5 +14,5 @@ Happy loud sniping!
 
 ## Releases
 
-## 2019-03-26_16-20-00 :: [f05c4fdb](https://github.com/highfidelity/hifi-content/commit/f05c4fdb)
+## 2019-04-15_13-00-00 :: [e1f15490](https://github.com/highfidelity/hifi-content/commit/e1f15490)
 - Initial release

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -16,5 +16,5 @@ When added to a zone entity, this script will automatically unmute a user when t
 
 # Releases
 
-## 2019-04-09_7-00-00 :: [df7677bc](https://github.com/highfidelity/hifi-content/commit/df7677bc)
+## 2019-04-15_13-00-00 :: [df7677bc](https://github.com/highfidelity/hifi-content/commit/df7677bc)
 - Initial release

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -11,6 +11,9 @@ When added to a zone entity, this script will automatically unmute a user when t
 2. Select the zone entity with the Create Tool
 3. Add `unmuteZoneClient.js` to the "Script" section
 
+## Exclusions
+- Push-to-talk is unaffected in the zone
+
 # Releases
 
 ## 2019-04-09_7-00-00 :: [df7677bc](https://github.com/highfidelity/hifi-content/commit/df7677bc)

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -1,0 +1,17 @@
+# Unmute Zone
+When this script is added to a zone as a client entity script, the zone will unmute when the person is inside the zone.
+
+## Features
+- Unmute zone will unmute a person when inside the zone
+- Leaving the zone, the script will set your mute status back to the previous setting upon entering the zone
+- If a user mutes themselves inside the zone, the zone will not change your mute settings after leaving the zone
+
+## Setup
+1. Add a zone entity to your domain
+2. Select the zone entity with the Create Tool
+3. Add `unmuteZoneClient.js` to the "Script" section
+
+# Releases
+
+## 2019-04-09_7-00-00 :: [5d396c5](https://github.com/highfidelity/hifi-content/commit/5d396c5)
+- Initial release

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -1,10 +1,10 @@
 # Unmute Zone
-When this script is added to a zone as a client entity script, the zone will unmute when the person is inside the zone.
+When added to a zone entity, this script will automatically unmute a user when the user is inside the zone.
 
 ## Features
-- Unmute zone will unmute a person when inside the zone
-- Leaving the zone, the script will set your mute status back to the previous setting upon entering the zone
-- If a user mutes themselves inside the zone, the zone will not change your mute settings after leaving the zone
+- On entering the zone, you will be unmuted
+- On leaving the zone, you will have your previous mute setting applied
+- If a user mutes themselves inside the zone, the zone will not apply your previous mute setting
 
 ## Setup
 1. Add a zone entity to your domain
@@ -13,5 +13,5 @@ When this script is added to a zone as a client entity script, the zone will unm
 
 # Releases
 
-## 2019-04-09_7-00-00 :: [5d396c5](https://github.com/highfidelity/hifi-content/commit/5d396c5)
+## 2019-04-09_7-00-00 :: [fac54005](https://github.com/highfidelity/hifi-content/commit/fac54005)
 - Initial release

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -13,5 +13,5 @@ When added to a zone entity, this script will automatically unmute a user when t
 
 # Releases
 
-## 2019-04-09_7-00-00 :: [fac54005](https://github.com/highfidelity/hifi-content/commit/fac54005)
+## 2019-04-09_7-00-00 :: [df7677bc](https://github.com/highfidelity/hifi-content/commit/df7677bc)
 - Initial release

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -2,7 +2,7 @@
 When added to a zone entity, this script will automatically unmute a user when the user is inside the zone.
 
 ## Features
-- On entering the zone, you will be unmuted
+- On entering the zone, you will be unmuted (unless you have Push-to-Talk enabled)
 - On leaving the zone, you will have your previous mute setting applied
 - If a user mutes themselves inside the zone, the zone will not apply your previous mute setting
 

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -16,5 +16,5 @@ When added to a zone entity, this script will automatically unmute a user when t
 
 # Releases
 
-## 2019-04-15_13-00-00 :: [e1f15490](https://github.com/highfidelity/hifi-content/commit/e1f15490)
+## 2019-04-15_13-00-00 :: [d8a4e4d1](https://github.com/highfidelity/hifi-content/commit/d8a4e4d1)
 - Initial release

--- a/usefulUtilities/unmuteZone/README.md
+++ b/usefulUtilities/unmuteZone/README.md
@@ -16,5 +16,5 @@ When added to a zone entity, this script will automatically unmute a user when t
 
 # Releases
 
-## 2019-04-15_13-00-00 :: [df7677bc](https://github.com/highfidelity/hifi-content/commit/df7677bc)
+## 2019-04-15_13-00-00 :: [e1f15490](https://github.com/highfidelity/hifi-content/commit/e1f15490)
 - Initial release

--- a/usefulUtilities/unmuteZone/unmuteZoneClient.js
+++ b/usefulUtilities/unmuteZone/unmuteZoneClient.js
@@ -26,7 +26,7 @@
         isMutedSignalConnected = false;
     UnmuteZoneClient.prototype = {
         preload: function(id) {
-            
+            // blank
         },
         enterEntity: function() {
             // save previous muted setting

--- a/usefulUtilities/unmuteZone/unmuteZoneClient.js
+++ b/usefulUtilities/unmuteZone/unmuteZoneClient.js
@@ -37,8 +37,7 @@
 
             // save previous muted setting
             previousMuteSetting = Audio.muted;
-            Audio.muted = false;
-            
+            Audio.muted = false;            
             usePreviousMuteSetting = true;
 
             Audio.mutedChanged.connect(onMuteSettingChanged);

--- a/usefulUtilities/unmuteZone/unmuteZoneClient.js
+++ b/usefulUtilities/unmuteZone/unmuteZoneClient.js
@@ -1,9 +1,6 @@
 //
 //  unmuteZoneClient.js
 //
-//  Add this script to a zone entity as a client script.
-//  Users that enter the zone will be unmuted.
-//
 //  Created by Robin Wilson on 2019-04-08
 //  Copyright 2019 High Fidelity, Inc.
 //
@@ -24,36 +21,41 @@
     }
 
 
-    var previousMuteSetting,
-        usePreviousMuteSetting,
-        isConnected;
+    var previousMuteSetting = false,
+        usePreviousMuteSetting = true,
+        isMutedSignalConnected = false;
     UnmuteZoneClient.prototype = {
         preload: function(id) {
             
         },
         enterEntity: function() {
+            // save previous muted setting
             previousMuteSetting = Audio.muted;
             Audio.muted = false;
             
             usePreviousMuteSetting = true;
+
             Audio.mutedChanged.connect(onMuteSettingChanged);
-            isConnected = true;
+            isMutedSignalConnected = true;
         },
         leaveEntity: function() {
             if (usePreviousMuteSetting) {
+                // did not change muted status while inside the zone
+                // apply previous setting
                 Audio.muted = previousMuteSetting;
             }
-            if (isConnected) {
+
+            if (isMutedSignalConnected) {
                 // only disconnect once
                 Audio.mutedChanged.disconnect(onMuteSettingChanged);
-                isConnected = false;
+                isMutedSignalConnected = false;
             }
         },
         unload: function() {
-            if (isConnected) {
+            if (isMutedSignalConnected) {
                 // only disconnect once
                 Audio.mutedChanged.disconnect(onMuteSettingChanged);
-                isConnected = false;
+                isMutedSignalConnected = false;
             }
         }
     };

--- a/usefulUtilities/unmuteZone/unmuteZoneClient.js
+++ b/usefulUtilities/unmuteZone/unmuteZoneClient.js
@@ -29,6 +29,12 @@
             // blank
         },
         enterEntity: function() {
+            // if push to talk is enabled
+            // exit
+            if (Audio.pushToTalk) {
+                return;
+            }
+
             // save previous muted setting
             previousMuteSetting = Audio.muted;
             Audio.muted = false;

--- a/usefulUtilities/unmuteZone/unmuteZoneClient.js
+++ b/usefulUtilities/unmuteZone/unmuteZoneClient.js
@@ -1,0 +1,63 @@
+//
+//  unmuteZoneClient.js
+//
+//  Add this script to a zone entity as a client script.
+//  Users that enter the zone will be unmuted.
+//
+//  Created by Robin Wilson on 2019-04-08
+//  Copyright 2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+(function() {
+    
+    function onMuteSettingChanged() {
+        // if user mutes themselves in the zone, 
+        // do not apply the previous mute setting
+        usePreviousMuteSetting = false;
+    }
+    
+    
+    function UnmuteZoneClient () {
+        // blank
+    }
+
+
+    var previousMuteSetting,
+        usePreviousMuteSetting,
+        isConnected;
+    UnmuteZoneClient.prototype = {
+        preload: function(id) {
+            
+        },
+        enterEntity: function() {
+            previousMuteSetting = Audio.muted;
+            Audio.muted = false;
+            
+            usePreviousMuteSetting = true;
+            Audio.mutedChanged.connect(onMuteSettingChanged);
+            isConnected = true;
+        },
+        leaveEntity: function() {
+            if (usePreviousMuteSetting) {
+                Audio.muted = previousMuteSetting;
+            }
+            if (isConnected) {
+                // only disconnect once
+                Audio.mutedChanged.disconnect(onMuteSettingChanged);
+                isConnected = false;
+            }
+        },
+        unload: function() {
+            if (isConnected) {
+                // only disconnect once
+                Audio.mutedChanged.disconnect(onMuteSettingChanged);
+                isConnected = false;
+            }
+        }
+    };
+
+    
+    return new UnmuteZoneClient();
+});


### PR DESCRIPTION
# Unmute Zone
When added to a zone entity, this script will automatically unmute a user when the user is inside the zone.

## Setup
1. Add a zone entity to your domain
2. Select the zone entity with the Create Tool
3. Add `unmuteZoneClient.js` (below URL) to the "Script" section

https://hifi-content.s3.amazonaws.com/Experiences/Releases/usefulUtilities/unmuteZone/2019-04-09_7-00-00/unmuteZoneClient.js

## Testing Expected Behavior
- On entering the zone, you will be unmuted
- On leaving the zone, you will have your previous mute setting applied
- If a user mutes themselves inside the zone, the zone will not apply your previous mute setting