### PR TITLE
Better Portal bookmarks

### DIFF
--- a/usefulUtilities/portal/README.md
+++ b/usefulUtilities/portal/README.md
@@ -22,7 +22,7 @@ The avatar's location will be changed using the `window.location` scripting inte
 If you set the `destination` value using the syntax `bookmark:<bookmark name>`, then the portal will move the user to the location specified by that named bookmark (which is stored on the user's hard drive in `bookmarks.json`).
 
 # Release Notes
-## v1.2 :: [ea202c9](https://github.com/highfidelity/hifi-content/commit/ea202c9)
+## v1.2 :: [cf7e6d2](https://github.com/highfidelity/hifi-content/commit/cf7e6d2)
 - Added the ability for a portal to send users to a location specified by a bookmark (_any_ bookmark!). Bookmarks are stored in a `bookmarks.json` file on the user's hard drive.
 
 ## v1.1 :: [ea202c9](https://github.com/highfidelity/hifi-content/commit/ea202c9)

--- a/usefulUtilities/portal/README.md
+++ b/usefulUtilities/portal/README.md
@@ -21,9 +21,10 @@ The avatar's location will be changed using the `window.location` scripting inte
 
 If you set the `destination` value using the syntax `bookmark:<bookmark name>`, then the portal will move the user to the location specified by that named bookmark (which is stored on the user's hard drive in `bookmarks.json`).
 
-**The only supported bookmark name as of Portal v1.1 is "Home".** If you try to use a different bookmark name, such as `bookmark:test`, the portal will do nothing to users who enter it (except print a log to their log file).
-
 # Release Notes
+## v1.2 :: [ea202c9](https://github.com/highfidelity/hifi-content/commit/ea202c9)
+- Added the ability for a portal to send users to a location specified by a bookmark (_any_ bookmark!). Bookmarks are stored in a `bookmarks.json` file on the user's hard drive.
+
 ## v1.1 :: [ea202c9](https://github.com/highfidelity/hifi-content/commit/ea202c9)
 - Added the ability for a portal to send users to a location specified by the bookmark called "Home" (and _only_ "Home"). Bookmarks are stored in a `bookmarks.json` file on the user's hard drive.
 

--- a/usefulUtilities/portal/portal.js
+++ b/usefulUtilities/portal/portal.js
@@ -7,9 +7,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
 (function () {
-    var HOME_BOOKMARK_NAME = "Home"; // This must match `LocationBookmarks::HOME_BOOKMARK`
-
-
     var Portal = function() {};
 
 
@@ -30,13 +27,7 @@
 
                     if (userData.destination.indexOf("bookmark:") > -1) {
                         var bookmarkName = userData.destination.replace("bookmark:", "");
-                        
-                        if (bookmarkName !== HOME_BOOKMARK_NAME) {
-                            console.log('The only supported bookmark name right now is "Home".');
-                            return;
-                        } else {
-                            destination = LocationBookmarks.getHomeLocationAddress();
-                        }
+                        destination = LocationBookmarks.getAddress(bookmarkName);
                     }
                     
                     Window.location = destination;


### PR DESCRIPTION
- Added the ability for a portal to send users to a location specified by a bookmark (_any_ bookmark!). Bookmarks are stored in a `bookmarks.json` file on the user's hard drive.

https://hifi-content.s3.amazonaws.com/Experiences/Releases/usefulUtilities/portal/v1.2/portal.js

[BUGZ-671](https://highfidelity.atlassian.net/browse/BUGZ-671)