### PR TITLE
BUGZ-922: Mirror is too dark in Interface after PR #15862

### DIFF
--- a/usefulUtilities/mirror/README.md
+++ b/usefulUtilities/mirror/README.md
@@ -8,3 +8,9 @@ The maximum pixel resolution of the mirror is 960px on the mirror's long side. T
 ## Version 2019-01-14_09_40_00
 commit 38a75210f31c46b4b23b285859d2f33159fce163
 - Initial release
+
+## Version 2019-07-03_10_20_00
+commit 12f28b5f47d3905d1dbaf93f5199a294d709e1f5
+- Fixed a hack in which the mirrors were darkened to compensate for the secondary camera being too light.
+- If your mirrors look too light, it means you have an older version of Interface (pre PR #15862) and should go back to the previous version of this script.
+- If your mirrors look too dark, it means you have a newer version of Interface (post PR #15682) and should update to the current version of this script.

--- a/usefulUtilities/mirror/mirrorClient.js
+++ b/usefulUtilities/mirror/mirrorClient.js
@@ -118,7 +118,6 @@
                 spectatorCameraConfig.attachedEntityId = _this.entityID;
                 previousFarClipDistance = spectatorCameraConfig.farClipPlaneDistance;
                 spectatorCameraConfig.farClipPlaneDistance = FAR_CLIP_DISTANCE;
-                Render.getConfig("SecondaryCameraJob.ToneMapping").curve = 0;
                 var mirrorEntityDimensions = Entities.getEntityProperties(_this.entityID, 'dimensions').dimensions;
                 var initialResolution = _this.calculateMirrorResolution(mirrorEntityDimensions);
                 spectatorCameraConfig.resetSizeSpectatorCamera(initialResolution.x, initialResolution.y);
@@ -138,7 +137,6 @@
             spectatorCameraConfig.mirrorProjection = false;
             spectatorCameraConfig.attachedEntityId = null;
             spectatorCameraConfig.farClipPlaneDistance = previousFarClipDistance;
-            Render.getConfig("SecondaryCameraJob.ToneMapping").curve = 1;
             Overlays.deleteOverlay(mirrorOverlayID);
             Script.update.disconnect(updateMirrorDimensions);
             mirrorOverlayRunning = false;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-922

Deleted all lines that messed with the secondary camera's tone mapping curve, since this is no longer necessary after PR #15862.