### PR TITLE
Fix mirrorReflection calling method names

### DIFF
--- a/usefulUtilities/mirror/README.md
+++ b/usefulUtilities/mirror/README.md
@@ -5,15 +5,19 @@
 The maximum pixel resolution of the mirror is 960px on the mirror's long side. The pixel resolution of the short side of the mirror is based on the aspect ratio of the mirror to ensure square pixels, and will always be smaller than 960px.
 
 # Release Notes
-## Version 2019-01-14_09_40_00
-commit 38a75210f31c46b4b23b285859d2f33159fce163
-- Initial release
+## Version 2019-07-24_09-18-00
+commit
+- Fixed a nasty bug that caused the mirror not to turn on or off.
 
 ## Version 2019-07-03_10_20_00
 commit 12f28b5f47d3905d1dbaf93f5199a294d709e1f5
 - Fixed a hack in which the mirrors were darkened to compensate for the secondary camera being too light.
 - If your mirrors look too light, it means you have an older version of Interface (pre PR #15862) and should go back to the previous version of this script.
 - If your mirrors look too dark, it means you have a newer version of Interface (post PR #15682) and should update to the current version of this script.
+
+## Version 2019-01-14_09_40_00
+commit 38a75210f31c46b4b23b285859d2f33159fce163
+- Initial release
 
 # Known Issues
 - mirrorClient.js uses an update loop instead of a timer.

--- a/usefulUtilities/mirror/README.md
+++ b/usefulUtilities/mirror/README.md
@@ -6,7 +6,7 @@ The maximum pixel resolution of the mirror is 960px on the mirror's long side. T
 
 # Release Notes
 ## Version 2019-07-24_09-18-00
-commit
+commit 9cd250fe397a88f90108a49559934fbec7f639bd
 - Fixed a nasty bug that caused the mirror not to turn on or off.
 
 ## Version 2019-07-03_10_20_00

--- a/usefulUtilities/mirror/mirrorReflection.js
+++ b/usefulUtilities/mirror/mirrorReflection.js
@@ -22,11 +22,11 @@
 
     // when avatar enters reflection area, begin reflecting
     this.enterEntity = function(entityID){
-        Entities.callEntityMethod(mirrorID, 'mirrorOverlayOn');
+        Entities.callEntityMethod(mirrorID, 'mirrorLocalEntityOn');
     };
 
     // when avatar leaves reflection area, stop reflecting
     this.leaveEntity = function (entityID) {
-        Entities.callEntityMethod(mirrorID, 'mirrorOverlayOff');
+        Entities.callEntityMethod(mirrorID, 'mirrorLocalEntityOff');
     };
 });


### PR DESCRIPTION
I'm not sure how this code worked before - it must not have!

https://highfidelity.atlassian.net/browse/BUGZ-1096

https://content.highfidelity.com/Experiences/Releases/usefulUtilities/mirror/2019-07-24_09-18-00/mirrorClient.js
https://content.highfidelity.com/Experiences/Releases/usefulUtilities/mirror/2019-07-24_09-18-00/mirrorReflection.js