### PR TITLE
DEV-302: Don't show the 'UNKNOWN TEAM' header when that's the only org name specified

### DIFF
--- a/usefulUtilities/statusIndicator/README.md
+++ b/usefulUtilities/statusIndicator/README.md
@@ -73,7 +73,10 @@ You can perform a local 1-person test of this new code by doing the following:
 
 # Release Notes
 
-## v2.5 | 2019-07-16_11-06-29 | [commit 0ba3f3c](https://github.com/highfidelity/hifi-content/commits/0ba3f3c)
+## Backend: v2.5 | Interface App: 2019-07-16_11-06-29 | [commit 4ad6031](https://github.com/highfidelity/hifi-content/commits/4ad6031)
+- On the status indicator website, don't show the 'UNKNOWN TEAM' header when that's the only org name returned in the results. Instead, show "PEOPLE".
+
+## v2.4 | 2019-07-16_11-06-29 | [commit 0ba3f3c](https://github.com/highfidelity/hifi-content/commits/0ba3f3c)
 - Updated `statusIndicator.js` to remove session display name logic.
 
 ## v2.4 | 2019-06-25_15-46-00 | [commit ac44aee](https://github.com/highfidelity/hifi-content/commits/ac44aee)

--- a/usefulUtilities/statusIndicator/webApp/www/js/formatStatusData.js
+++ b/usefulUtilities/statusIndicator/webApp/www/js/formatStatusData.js
@@ -1,11 +1,12 @@
 var UNSET_DISPLAY_NAME_STRING = "unset display name";
 var UNKNOWN_TEAM_STRING = "Unknown Team";
+var ONE_UNKNOWN_TEAM_STRING = "People";
 var UNKNOWN_LOCATION_STRING = "online";
 
 function formatStatusData(data) {
     var generatedContainerDiv = document.createElement("div");
     if (data.teams.length === 0) {
-        document.getElementById("content").innerHTML = `<h2>No employee data.</h2>`;
+        document.getElementById("content").innerHTML = `<h2>There's no status data available for the specified organization.</h2>`;
         return;
     }
 
@@ -14,7 +15,11 @@ function formatStatusData(data) {
     for (var i = 0; i < data.teams.length; i++) {
         var currentTeamName = data.teams[i].name;
         if (currentTeamName === "TBD") {
-            currentTeamName = UNKNOWN_TEAM_STRING;
+            if (data.teams.length === 1) {
+                currentTeamName = ONE_UNKNOWN_TEAM_STRING;
+            } else {
+                currentTeamName = UNKNOWN_TEAM_STRING;
+            }
         }
 
         var teamContainer = document.createElement("div");


### PR DESCRIPTION
[DEV-302](https://highfidelity.atlassian.net/browse/DEV-302)

QA can happen before and after this code deploy by going to:
https://www.highfidelity.co/statusIndicator/allEmployees.html?organization=test

Before, you'll see "UNKNOWN TEAM" as the header. After, you'll see "PEOPLE".