### PR TITLE
BUGZ-1125: Mirror entity should not be grabbable

### DIFF
--- a/usefulUtilities/mirror/README.md
+++ b/usefulUtilities/mirror/README.md
@@ -5,6 +5,10 @@
 The maximum pixel resolution of the mirror is 960px on the mirror's long side. The pixel resolution of the short side of the mirror is based on the aspect ratio of the mirror to ensure square pixels, and will always be smaller than 960px.
 
 # Release Notes
+## Version 2019-08-01_13-02-00
+commit 550bb2ba
+- Made the mirror local entity not grabbable
+
 ## Version 2019-07-24_09-18-00
 commit 9cd250fe397a88f90108a49559934fbec7f639bd
 - Fixed a nasty bug that caused the mirror not to turn on or off.

--- a/usefulUtilities/mirror/mirrorClient.js
+++ b/usefulUtilities/mirror/mirrorClient.js
@@ -91,6 +91,9 @@
                     x: 0,
                     y: 0,
                     z: mirrorLocalEntityOffset
+                },                
+                grab: {
+                    grabbable: false
                 },
                 localRotation: Quat.fromPitchYawRollDegrees(0, 0, 180),
                 isVisibleInSecondaryCamera: false


### PR DESCRIPTION
made the local mirror entity created in mirrorClient.js not grabbable.
https://highfidelity.atlassian.net/browse/BUGZ-1125