### PR TITLE
BUGZ-1386: Update simplifiedStatusIndicator to use domainID as org name instead of location.hostname

### DIFF
--- a/usefulUtilities/statusIndicator/README.md
+++ b/usefulUtilities/statusIndicator/README.md
@@ -77,6 +77,10 @@ You can perform a local test of the Status Indicator system by doing the followi
 
 # Release Notes
 
+## Backend: v2.6 | Interface Scripts: 2019-08-30_11-39-00 | [commit xxxxxxx](https://github.com/highfidelity/hifi-content/commits/xxxxxxx)
+- The Status Update's "organization" will now be `location.domainID` instead of `location.hostname`.
+- The Directory Client Script will now propertly set the organization of the Web Entity based on `location.domainID`.
+
 ## Backend: v2.6 | Interface App: 2019-07-26_10-50-00 | [commit 134bb43](https://github.com/highfidelity/hifi-content/commits/134bb43)
 - Completely removed the notion of "team names" from Status Indicator. This means `teamPage.html` no longer exists, and interfaces that get data from the server via the status indicator backend APIs can no longer be formatted based off of team names.
 

--- a/usefulUtilities/statusIndicator/README.md
+++ b/usefulUtilities/statusIndicator/README.md
@@ -77,7 +77,7 @@ You can perform a local test of the Status Indicator system by doing the followi
 
 # Release Notes
 
-## Backend: v2.6 | Interface Scripts: 2019-08-30_11-39-00 | [commit xxxxxxx](https://github.com/highfidelity/hifi-content/commits/xxxxxxx)
+## Backend: v2.6 | Interface Scripts: 2019-08-30_11-39-00 | [commit 6504ca2](https://github.com/highfidelity/hifi-content/commits/6504ca2)
 - The Status Update's "organization" will now be `location.domainID` instead of `location.hostname`.
 - The Directory Client Script will now propertly set the organization of the Web Entity based on `location.domainID`.
 

--- a/usefulUtilities/statusIndicator/hifiScript/directoryClientScript/directoryClientScript.js
+++ b/usefulUtilities/statusIndicator/hifiScript/directoryClientScript/directoryClientScript.js
@@ -22,7 +22,9 @@
         }
 
         var currentURL = Entities.getEntityProperties(id, ["sourceUrl"]).sourceUrl;
-        var newURL = DIRECTORY_URL_BASE + AddressManager.hostname;
+        var domainID = location.domainID;
+        domainID = domainID.substring(1, domainID.length - 1);
+        var newURL = DIRECTORY_URL_BASE + domainID;
         if (currentURL !== newURL) {
             Entities.editEntity(id, {sourceUrl: newURL});
         }

--- a/usefulUtilities/statusIndicator/hifiScript/statusIndicator.js
+++ b/usefulUtilities/statusIndicator/hifiScript/statusIndicator.js
@@ -128,7 +128,9 @@
 
         queryParamString += "&displayName=" + displayNameToSend;
         queryParamString += "&status=" + currentStatus;
-        queryParamString += "&organization=" + location.hostname;
+        var domainID = location.domainID;
+        domainID = domainID.substring(1, domainID.length - 1);
+        queryParamString += "&organization=" + domainID;
 
         var uri = REQUEST_URL + "?" + queryParamString;
 


### PR DESCRIPTION
[BUGZ-1386](https://highfidelity.atlassian.net/browse/BUGZ-1386)

Directory client script:
https://content.highfidelity.com/Experiences/Releases/usefulUtilities/statusIndicator/2019-08-30_11-39-00/hifiScript/directoryClientScript/directoryClientScript.js

Status indicator script:
https://content.highfidelity.com/Experiences/Releases/usefulUtilities/statusIndicator/2019-08-30_11-39-00/hifiScript/statusIndicator.js